### PR TITLE
Brought `ocm-sdk-go` logger locally to add functionality

### DIFF
--- a/cmd/ocm-load-test.go
+++ b/cmd/ocm-load-test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/cloud-bulldozer/ocm-api-load/pkg/cmd"
 	"github.com/cloud-bulldozer/ocm-api-load/pkg/helpers"
+	"github.com/cloud-bulldozer/ocm-api-load/pkg/logging"
 	"github.com/cloud-bulldozer/ocm-api-load/pkg/tests"
-	"github.com/openshift-online/ocm-sdk-go/logging"
 	uuid "github.com/satori/go.uuid"
 	"github.com/spf13/cobra"
 

--- a/pkg/helpers/clean_clusters_transport.go
+++ b/pkg/helpers/clean_clusters_transport.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/openshift-online/ocm-sdk-go/logging"
+	"github.com/cloud-bulldozer/ocm-api-load/pkg/logging"
 )
 
 type CleanClustersTransport struct {

--- a/pkg/helpers/connection.go
+++ b/pkg/helpers/connection.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 
 	sdk "github.com/openshift-online/ocm-sdk-go"
-	"github.com/openshift-online/ocm-sdk-go/logging"
+	"github.com/cloud-bulldozer/ocm-api-load/pkg/logging"
 )
 
 // BuildConnection build the vegeta connection

--- a/pkg/helpers/file_system.go
+++ b/pkg/helpers/file_system.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/openshift-online/ocm-sdk-go/logging"
+	"github.com/cloud-bulldozer/ocm-api-load/pkg/logging"
 )
 
 // CreateFolder creates folder in the system

--- a/pkg/helpers/types.go
+++ b/pkg/helpers/types.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	sdk "github.com/openshift-online/ocm-sdk-go"
-	"github.com/openshift-online/ocm-sdk-go/logging"
+	"github.com/cloud-bulldozer/ocm-api-load/pkg/logging"
 	vegeta "github.com/tsenart/vegeta/v12/lib"
 )
 

--- a/pkg/logging/go_logger.go
+++ b/pkg/logging/go_logger.go
@@ -1,0 +1,170 @@
+/*
+Copyright (c) 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file contains a logger that uses the Go `log` package.
+
+package logging
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+)
+
+// GoLoggerBuilder contains the configuration and logic needed to build a logger that uses the Go
+// `log` package. Don't create instances of this type directly, use the NewGoLoggerBuilder function
+// instead.
+type GoLoggerBuilder struct {
+	debugEnabled bool
+	infoEnabled  bool
+	warnEnabled  bool
+	errorEnabled bool
+}
+
+// GoLogger is a logger that uses the Go `log` package.
+type GoLogger struct {
+	debugEnabled bool
+	infoEnabled  bool
+	warnEnabled  bool
+	errorEnabled bool
+}
+
+// NewGoLoggerBuilder creates a builder that knows how to build a logger that uses the Go `log`
+// package. By default these loggers will have enabled the information, warning and error levels
+func NewGoLoggerBuilder() *GoLoggerBuilder {
+	// Allocate the object:
+	builder := new(GoLoggerBuilder)
+
+	// Set default values:
+	builder.debugEnabled = false
+	builder.infoEnabled = true
+	builder.warnEnabled = true
+	builder.errorEnabled = true
+
+	return builder
+}
+
+// Debug enables or disables the debug level.
+func (b *GoLoggerBuilder) Debug(flag bool) *GoLoggerBuilder {
+	b.debugEnabled = flag
+	return b
+}
+
+// Info enables or disables the information level.
+func (b *GoLoggerBuilder) Info(flag bool) *GoLoggerBuilder {
+	b.infoEnabled = flag
+	return b
+}
+
+// Warn enables or disables the warning level.
+func (b *GoLoggerBuilder) Warn(flag bool) *GoLoggerBuilder {
+	b.warnEnabled = flag
+	return b
+}
+
+// Error enables or disables the error level.
+func (b *GoLoggerBuilder) Error(flag bool) *GoLoggerBuilder {
+	b.errorEnabled = flag
+	return b
+}
+
+// Build creates a new logger using the configuration stored in the builder.
+func (b *GoLoggerBuilder) Build() (logger *GoLogger, err error) {
+	// Allocate and populate the object:
+	logger = new(GoLogger)
+	logger.debugEnabled = b.debugEnabled
+	logger.infoEnabled = b.infoEnabled
+	logger.warnEnabled = b.warnEnabled
+	logger.errorEnabled = b.errorEnabled
+
+	return
+}
+
+// DebugEnabled returns true iff the debug level is enabled.
+func (l *GoLogger) DebugEnabled() bool {
+	return l.debugEnabled
+}
+
+// InfoEnabled returns true iff the information level is enabled.
+func (l *GoLogger) InfoEnabled() bool {
+	return l.infoEnabled
+}
+
+// WarnEnabled returns true iff the warning level is enabled.
+func (l *GoLogger) WarnEnabled() bool {
+	return l.warnEnabled
+}
+
+// ErrorEnabled returns true iff the error level is enabled.
+func (l *GoLogger) ErrorEnabled() bool {
+	return l.errorEnabled
+}
+
+// Debug sends to the log a debug message formatted using the fmt.Sprintf function and the given
+// format and arguments.
+func (l *GoLogger) Debug(ctx context.Context, format string, args ...interface{}) {
+	if l.debugEnabled {
+		format = appendHeader(Debug, format)
+		msg := fmt.Sprintf(format, args...)
+		// #nosec G104
+		log.Output(1, msg)
+	}
+}
+
+// Info sends to the log an information message formatted using the fmt.Sprintf function and the
+// given format and arguments.
+func (l *GoLogger) Info(ctx context.Context, format string, args ...interface{}) {
+	if l.infoEnabled {
+		format = appendHeader(Info, format)
+		msg := fmt.Sprintf(format, args...)
+		// #nosec G104
+		log.Output(1, msg)
+	}
+}
+
+// Warn sends to the log a warning message formatted using the fmt.Sprintf function and the given
+// format and arguments.
+func (l *GoLogger) Warn(ctx context.Context, format string, args ...interface{}) {
+	if l.warnEnabled {
+		format = appendHeader(Warning, format)
+		msg := fmt.Sprintf(format, args...)
+		// #nosec G104
+		log.Output(1, msg)
+	}
+}
+
+// Error sends to the log an error message formatted using the fmt.Sprintf function and the given
+// format and arguments.
+func (l *GoLogger) Error(ctx context.Context, format string, args ...interface{}) {
+	if l.errorEnabled {
+		format = appendHeader(Error, format)
+		msg := fmt.Sprintf(format, args...)
+		// #nosec G104
+		log.Output(1, msg)
+	}
+}
+
+// Fatal sends to the log an error message formatted using the fmt.Sprintf function and the given
+// format and arguments. After that it will os.Exit(1)
+// This level is always enabled
+func (l *GoLogger) Fatal(ctx context.Context, format string, args ...interface{}) {
+	format = appendHeader(Fatal, format)
+	msg := fmt.Sprintf(format, args...)
+	// #nosec G104
+	log.Output(1, msg)
+	os.Exit(1)
+}

--- a/pkg/logging/header.go
+++ b/pkg/logging/header.go
@@ -1,0 +1,32 @@
+package logging
+
+import "fmt"
+
+type Level int
+
+const (
+	Fatal Level = iota // 0
+	Error
+	Warning
+	Info
+	Debug
+)
+
+func appendHeader(l Level, msg string) string {
+	prepend := ""
+	switch l {
+	case Fatal:
+		prepend = "Fatal"
+	case Error:
+		prepend = "Error"
+	case Warning:
+		prepend = "Warning"
+	case Info:
+		prepend = "Info"
+	case Debug:
+		prepend = "Debug"
+
+	}
+	return fmt.Sprintf("%s - %s", prepend, msg)
+
+}

--- a/pkg/logging/header_test.go
+++ b/pkg/logging/header_test.go
@@ -1,0 +1,29 @@
+package logging
+
+import "testing"
+
+func Test_appendHeader(t *testing.T) {
+	type args struct {
+		l   Level
+		msg string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{"1", args{Debug, "test %v"}, "Debug - test %v"},
+		{"2", args{Info, "test %v"}, "Info - test %v"},
+		{"3", args{Warning, "test %v"}, "Warning - test %v"},
+		{"4", args{Error, "test %v"}, "Error - test %v"},
+		{"5", args{Fatal, "test %v"}, "Fatal - test %v"},
+		{"6", args{Info, "test %v - %s - %d"}, "Info - test %v - %s - %d"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := appendHeader(tt.args.l, tt.args.msg); got != tt.want {
+				t.Errorf("appendHeader() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -1,0 +1,65 @@
+/*
+Copyright (c) 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file contains the definition of the logger interface that is used by the client.
+
+package logging
+
+import (
+	"context"
+)
+
+// Logger is the interface that must be implemented by objects that are used for logging by the
+// client. By default the client uses a logger based on the `glog` package, but that can be changed
+// using the `Logger` method of the builder.
+//
+// Note that the context is optional in most of the methods of the SDK, so implementations of this
+// interface must accept and handle smoothly calls to the Debug, Info, Warn and Error methods where
+// the ctx parameter is nil.
+type Logger interface {
+	// DebugEnabled returns true if the debug level is enabled.
+	DebugEnabled() bool
+
+	// InfoEnabled returns true if the information level is enabled.
+	InfoEnabled() bool
+
+	// WarnEnabled returns true if the warning level is enabled.
+	WarnEnabled() bool
+
+	// ErrorEnabled returns true if the error level is enabled.
+	ErrorEnabled() bool
+
+	// Debug sends to the log a debug message formatted using the fmt.Sprintf function and the
+	// given format and arguments.
+	Debug(ctx context.Context, format string, args ...interface{})
+
+	// Info sends to the log an information message formatted using the fmt.Sprintf function and
+	// the given format and arguments.
+	Info(ctx context.Context, format string, args ...interface{})
+
+	// Warn sends to the log a warning message formatted using the fmt.Sprintf function and the
+	// given format and arguments.
+	Warn(ctx context.Context, format string, args ...interface{})
+
+	// Error sends to the log an error message formatted using the fmt.Sprintf function and the
+	// given format and arguments.
+	Error(ctx context.Context, format string, args ...interface{})
+
+	// Fatal sends to the log an error message formatted using the fmt.Sprintf function and the
+	// given format and arguments; and then executes an os.Exit(1)
+	// Fatal level is always enabled
+	Fatal(ctx context.Context, format string, args ...interface{})
+}

--- a/pkg/tests/run.go
+++ b/pkg/tests/run.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/cloud-bulldozer/ocm-api-load/pkg/helpers"
+	"github.com/cloud-bulldozer/ocm-api-load/pkg/logging"
 	sdk "github.com/openshift-online/ocm-sdk-go"
-	"github.com/openshift-online/ocm-sdk-go/logging"
 	"github.com/spf13/viper"
 	vegeta "github.com/tsenart/vegeta/v12/lib"
 )


### PR DESCRIPTION
Signed-off-by: Vicente Zepeda Mas <vzepedam@redhat.com>

### Description

`ocm-sdk-go` doesn't want to add extra functionality to their loggers, so we need to add them on our side.

### Fixes
