### PR TITLE
Use CCS in 'create-cluster' test

### DIFF
--- a/cmd/ocm-load-test.go
+++ b/cmd/ocm-load-test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -10,28 +11,26 @@ import (
 	"github.com/cloud-bulldozer/ocm-api-load/pkg/helpers"
 	"github.com/cloud-bulldozer/ocm-api-load/pkg/logging"
 	"github.com/cloud-bulldozer/ocm-api-load/pkg/tests"
-	uuid "github.com/satori/go.uuid"
+	sdk "github.com/openshift-online/ocm-sdk-go"
 	"github.com/spf13/cobra"
-
 	"github.com/spf13/viper"
 )
 
+// Cobra requires a variable to store each command-line argument's value. These
+// variables serve that purpose.
 var (
-	configFile  string
-	ocmTokenURL string
-	ocmToken    string
-	testID      string
-	outputPath  string
-	duration    int
-	rate        string
-	gatewayUrl  string
-	testNames   []string
-	verbose     bool
-
-	// These are specific to the `create cluster` test.
-	// TODO: Refactor the test-suite in a way where variables specific to only
-	//       a single test aren't squeezed in with generic variables used by
-	//       all tests.
+	configFile   string
+	ocmTokenURL  string
+	ocmToken     string
+	testID       string
+	outputPath   string
+	duration     int
+	rate         string
+	gatewayUrl   string
+	clientSecret string
+	clientID     string
+	testName     string
+	verbose      bool
 	ccsAccountID string
 	ccsAccessKey string
 	ccsSecretKey string
@@ -43,11 +42,7 @@ const (
 	A set of load tests for OCM's clusters-service, based on vegeta.
 	For example:
 
-	ocm-load-test --test-id=foo --ocm-token=$OCM_TOKEN --duration=20m --rate=5/s --output-path=./results/$TEST_ID_$TEST_NAME.json <test_name>
-
-	Or
-
-	ocm-load-test --config-file=config.yaml
+	ocm-load-test --ocm-token=$OCM_TOKEN --duration=20m --rate=5/s --output-path=./results/$TEST_ID_$TEST_NAME.json <test_name>
 `
 )
 
@@ -59,45 +54,38 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
-	cobra.OnInitialize(initConfig)
-	rootCmd.PersistentFlags().StringVar(&configFile, "config-file", "config.yaml", "config file")
+
+	// OCM Authentication
 	rootCmd.PersistentFlags().StringVar(&ocmTokenURL, "ocm-token-url", "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token", "Token URL")
 	rootCmd.PersistentFlags().StringVar(&ocmToken, "ocm-token", "", "OCM Authorization token")
+	rootCmd.MarkFlagRequired("ocm-token")
+
+	// API Endpoint
 	rootCmd.PersistentFlags().StringVar(&gatewayUrl, "gateway-url", "https://api.integration.openshift.com", "Gateway url to perform the test against")
-	rootCmd.PersistentFlags().StringVar(&testID, "test-id", uuid.NewV4().String(), "Unique ID to identify the test run. UUID is recommended")
-	rootCmd.PersistentFlags().StringVar(&outputPath, "output-path", "results", "Output directory for result and report files")
+	rootCmd.PersistentFlags().StringVar(&clientSecret, "client-secret", "", "Client Secret")
+	rootCmd.PersistentFlags().StringVar(&clientID, "client-id", "", "Client ID")
+
+	// Global Test Options
 	rootCmd.PersistentFlags().IntVar(&duration, "duration", 1, "Duration of each individual run in minutes.")
 	rootCmd.PersistentFlags().StringVar(&rate, "rate", "1/s", "Rate of the attack. Format example 5/s. (Available units 'ns', 'us', 'ms', 's', 'm', 'h')")
-	rootCmd.PersistentFlags().StringSliceVar(&testNames, "test-names", []string{}, "Names for the tests to be run.")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "set this flag to activate verbose logging.")
+	rootCmd.PersistentFlags().StringVar(&testName, "test-name", "", "Name of the test to run.") // TODO: Enumerate test names in help text
+	rootCmd.MarkFlagRequired("duration")
+	rootCmd.MarkFlagRequired("rate")
+	rootCmd.MarkFlagRequired("test-name")
+
+	// Create-Cluster (CCS) Options
 	rootCmd.PersistentFlags().StringVar(&ccsAccountID, "ccs-account-id", "", "AWS Account ID for CCS User")
 	rootCmd.PersistentFlags().StringVar(&ccsAccessKey, "ccs-access-key", "", "AWS Access Key for CCS User")
 	rootCmd.PersistentFlags().StringVar(&ccsSecretKey, "ccs-secret-key", "", "AWS Secret Key for CCS User")
 	rootCmd.PersistentFlags().StringVar(&ccsRegion, "ccs-region", "", "AWS Region for the 'create-cluster' Test")
+
+	// Sub-Commands
 	rootCmd.AddCommand(cmd.NewVersionCommand())
 }
 
-func initConfig() {
-	viper.SetConfigType("yaml")
-	if configFile == "" {
-		viper.AddConfigPath(".")
-	}
-	viper.SetConfigFile(configFile)
-	viper.BindPFlags(rootCmd.Flags())
-
-	viper.AutomaticEnv()
-
-	if _, err := os.Stat(configFile); err != nil {
-		viper.WriteConfig()
-	} else {
-		err := viper.ReadInConfig()
-		if err != nil {
-			panic(fmt.Errorf("fatal error config file: %s", err))
-		}
-	}
-}
-
-func run(cmd *cobra.Command, args []string) error {
+// initLogging initializes and returns the log handler
+func initLogging() *logging.GoLogger {
 	logger, err := logging.NewGoLoggerBuilder().
 		Debug(viper.GetBool("verbose")).
 		Build()
@@ -105,30 +93,49 @@ func run(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(os.Stderr, "Can't build logger: %v\n", err)
 		os.Exit(1)
 	}
+	return logger
+}
 
-	if viper.GetString("ocm-token") == "" {
-		logger.Fatal(cmd.Context(), "ocm-token is a necessary configuration")
-	}
-	err = helpers.CreateFolder(viper.GetString("output-path"), logger)
-	if err != nil {
-		logger.Fatal(cmd.Context(), "creating api connection: %v", err)
-	}
-	logger.Info(cmd.Context(), "Using output directory: %s", viper.GetString("output-path"))
+func initConnection(cmd *cobra.Command, logger *logging.GoLogger) *sdk.Connection {
 
-	connection, err := helpers.BuildConnection(viper.GetString("gateway-url"),
-		viper.GetString("client.id"),
-		viper.GetString("client.secret"),
-		viper.GetString("ocm-token"),
+	// Validate the values used here because BuildConnection does not always
+	// return the most useful error messages.
+	// ex: can't parse token 0: token contains an invalid number of segments
+	if len(gatewayUrl) == 0 {
+		logger.Fatal(cmd.Context(), "gatewayURL is invalid: %s", gatewayUrl)
+	}
+	if len(ocmToken) == 0 {
+		logger.Fatal(cmd.Context(), "ocm-token is invalid: '%s'", ocmToken)
+	}
+	logger.Info(cmd.Context(), "API Endpoint: %s", gatewayUrl)
+
+	connection, err := helpers.BuildConnection(
+		gatewayUrl,
+		clientID,
+		clientSecret,
+		ocmToken,
 		logger,
-		cmd.Context())
+		cmd.Context(),
+	)
 	if err != nil {
-		logger.Fatal(cmd.Context(), "creating api connection: %v", err)
+		logger.Fatal(cmd.Context(), "Unable to initialize connection object: %v", err)
 	}
+	return connection
+}
+
+func run(cmd *cobra.Command, args []string) error {
+
+	// Setup Logging
+	logger := initLogging()
+
+	// Construct an OCM Connection object which is used to handle all requests
+	// made to OCM and manages the associated authentication.
+	connection := initConnection(cmd, logger)
 	defer helpers.Cleanup(connection)
 
-	vegetaRate, err := helpers.ParseRate(viper.GetString("rate"))
+	vegetaRate, err := helpers.ParseRate(rate)
 	if err != nil {
-		logger.Fatal(cmd.Context(), "parsing rate: %v", err)
+		logger.Fatal(cmd.Context(), "Error parsing rate: %v", err)
 	}
 
 	// Flag overrides config
@@ -141,37 +148,28 @@ func run(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// If no Flag or Config is passed all test should run
-	if len(viper.GetStringSlice("test-names")) == 0 && len(viper.GetStringMap("tests")) == 0 {
-		viper.Set("tests.all", map[string]interface{}{})
+	// Require explicit declaration of the test to be ran to avoid any
+	// ambiguity on what is going to be executed. This also makes it easy to
+	// understand any console output that might be shared and archived in the
+	// future.
+	// TODO: Enumerate available test names.
+	if len(testName) == 0 {
+		return errors.New("No test name was specified.")
 	}
 
-	// Require CCS Credentials if `create-cluster` test is going to be be ran
-	// TODO: Perhaps we can introduce an optional "pre-check" for each test?
-	// TODO: Validate credentials work before using them since the affected test
-	//       may not be ran until a lot of other tests are performed.
-	//       (A pre-flight check, if you will)
-	isCCSRequired := false
-	if viper.Get("tests.all") != nil {
-		isCCSRequired = true
-	}
-	for _, testName := range viper.GetStringSlice("test-names") {
-		if testName == "create-cluster" {
-			isCCSRequired = true
+	// create-cluster requires additional configuration data to be provided.
+	if testName == "create-cluster" {
+		if len(ccsAccountID) == 0 {
+			return errors.New("ccs-account-id is required to run the create-cluster test.")
 		}
-	}
-	if isCCSRequired {
-		if len(viper.GetString("ccsAccountID")) == 0 {
-			logger.Fatal(cmd.Context(), "ccsAccountID is required to run the create-cluster test.")
+		if len(viper.GetString("ccs-access-key")) == 0 {
+			return errors.New("ccs-access-key is required to run the create-cluster test.")
 		}
-		if len(viper.GetString("ccsAccessKey")) == 0 {
-			logger.Fatal(cmd.Context(), "ccsAccessKey is required to run the create-cluster test.")
+		if len(viper.GetString("ccs-secret-key")) == 0 {
+			return errors.New("ccs-secret-key is required to run the create-cluster test.")
 		}
-		if len(viper.GetString("ccsSecretKey")) == 0 {
-			logger.Fatal(cmd.Context(), "ccsSecretKey is required to run the create-cluster test.")
-		}
-		if len(viper.GetString("ccsRegion")) == 0 {
-			logger.Fatal(cmd.Context(), "ccsRegion is required to run the create-cluster test.")
+		if len(viper.GetString("ccs-region")) == 0 {
+			return errors.New("ccs-region is required to run the create-cluster test.")
 		}
 	}
 

--- a/pkg/helpers/types.go
+++ b/pkg/helpers/types.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"time"
 
-	sdk "github.com/openshift-online/ocm-sdk-go"
 	"github.com/cloud-bulldozer/ocm-api-load/pkg/logging"
+	sdk "github.com/openshift-online/ocm-sdk-go"
 	vegeta "github.com/tsenart/vegeta/v12/lib"
 )
 
@@ -31,4 +31,22 @@ type TestOptions struct {
 	Encoder    *vegeta.Encoder // Encodes results and writes them to a File
 	Logger     logging.Logger
 	Context    context.Context
+
+	// Test-Specific Options
+	// TODO: Find a better way to pass these values to the individual tests
+	//       as this pattern could overcomplicate and significantly grow this
+	//       struct over time.
+	CCSAccessKey string
+	CCSSecretKey string
+	CCSAccountID string
+	CCSRegion    string
+}
+
+// AWSOptions is used to specify configuration options required when creating
+// (fake) clusters in a given AWS account.
+type AWSOptions struct {
+	CCSAccessKey string
+	CCSSecretKey string
+	CCSAccountID string
+	Region       string
 }

--- a/pkg/tests/handlers/clusters.go
+++ b/pkg/tests/handlers/clusters.go
@@ -14,6 +14,8 @@ func TestCreateCluster(options *helpers.TestOptions) error {
 
 	testName := options.TestName
 
+	fmt.Printf("Options: %+v\n", options)
+
 	awsOptions := &helpers.AWSOptions{
 		CCSAccessKey: options.CCSAccessKey,
 		CCSSecretKey: options.CCSSecretKey,
@@ -41,6 +43,8 @@ func generateCreateClusterTargeter(ID, method, url string, awsOptions *helpers.A
 	// Cluster Names must match the following regex:
 	// ^[a-z]([-a-z0-9]*[a-z0-9])?$
 	id := ID[:4]
+
+	fmt.Printf("AWS Options: %+v\n", awsOptions)
 
 	targeter := func(t *vegeta.Target) error {
 		fakeClusterProps := map[string]string{

--- a/pkg/tests/run.go
+++ b/pkg/tests/run.go
@@ -57,9 +57,13 @@ func Run(
 		//       a better way to pass these to the test(s) which requires them.
 		//       Don't forget to validate they are set on startup as opposed to
 		//       waiting for the dependent test to start running.
-		t.CCSAccessKey = viper.GetString("ccsAccounKey")
-		t.CCSSecretKey = viper.GetString("ccsSecretKey")
-		t.CCSAccountID = viper.GetString("ccsAccountID")
+		t.CCSAccessKey = viper.GetString("ccs-account-key")
+		t.CCSSecretKey = viper.GetString("ccs-secret-key")
+		t.CCSAccountID = viper.GetString("ccs-account-id")
+		t.CCSRegion = viper.GetString("ccs-region")
+
+		fmt.Printf("Test Options: %+v\n", t)
+		fmt.Printf("Test Option Access Key: %s", t.CCSAccessKey)
 
 		// Create the vegeta rate with the config values
 		if viper.GetString(fmt.Sprintf("%s.rate", t.TestName)) == "" {

--- a/pkg/tests/run.go
+++ b/pkg/tests/run.go
@@ -52,6 +52,15 @@ func Run(
 		t.Logger = logger
 		t.Context = ctx
 
+		// Bind additional test options
+		// TODO: These are only required for the `create-cluster` test. Find
+		//       a better way to pass these to the test(s) which requires them.
+		//       Don't forget to validate they are set on startup as opposed to
+		//       waiting for the dependent test to start running.
+		t.CCSAccessKey = viper.GetString("ccsAccounKey")
+		t.CCSSecretKey = viper.GetString("ccsSecretKey")
+		t.CCSAccountID = viper.GetString("ccsAccountID")
+
 		// Create the vegeta rate with the config values
 		if viper.GetString(fmt.Sprintf("%s.rate", t.TestName)) == "" {
 			logger.Info(ctx, "no specific rate for test %s. Using default", t.TestName)


### PR DESCRIPTION
Use CCS during `create-clusters` test to allow Users to supply their own AWS account.
