### PR TITLE
Use CCS in `create-cluster` test

### DIFF
--- a/cmd/ocm-load-test.go
+++ b/cmd/ocm-load-test.go
@@ -126,6 +126,10 @@ func run(cmd *cobra.Command, args []string) error {
 		viper.Set("tests.all", map[string]interface{}{})
 	}
 
+	// Ensure that the CCS Credentials are provided if create-cluster is going
+	// to be executed.
+	// TODO: Implement this based on the proposed YAML file schema
+
 	testConfig := types.TestConfiguration{
 		TestID:          viper.GetString("test-id"),
 		OutputDirectory: viper.GetString("output-path"),

--- a/cmd/ocm-load-test.go
+++ b/cmd/ocm-load-test.go
@@ -122,6 +122,11 @@ func configAWS(ctx context.Context, logger *logging.GoLogger) {
 	if len(viper.Get("aws").([]interface{})) < 1 {
 		logger.Fatal(ctx, "AWS configuration not provided")
 	}
+
+	// If multiple accounts are passed.
+	if len(viper.Get("aws").([]interface{})) > 1 {
+		logger.Fatal(ctx, "Multiple AWS accounts are not supported at the moment")
+	}
 }
 
 func run(cmd *cobra.Command, args []string) error {

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -5,6 +5,15 @@ gateway-url: http://localhost:8000  # Gateway URL.
 client:
   - id: cloud-services              # OpenID client identifier.
   - secret: "secure-secret"         # OpenID client secret.
+aws:
+  - region: "us-west-1"
+    access-key: "ASD7ASFET65FFGHDFFS"
+    secret-access-key: "fjhgsadf6#$!@%&/dfghdfgdsdf"
+    account-id: "123434565665"
+  - region: "us-west-2"
+    access-key: "ASD7ASFET65FFGHDFFS"
+    secret-access-key: "fjhgsadf6#$!@%&/dfghdfgdsdf"
+    account-id: "123434565665"
 duration: 2
 cooldown: 10
 output-path: "./results"

--- a/pkg/tests/handlers/clusters.go
+++ b/pkg/tests/handlers/clusters.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/cloud-bulldozer/ocm-api-load/pkg/helpers"
 	"github.com/cloud-bulldozer/ocm-api-load/pkg/types"
 
 	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
@@ -34,6 +33,14 @@ func generateCreateClusterTargeter(ID, method, url string) vegeta.Targeter {
 	// ^[a-z]([-a-z0-9]*[a-z0-9])?$
 	id := ID[:4]
 
+	// CCS is used to create fake clusters within the AWS
+	// environment supplied by the user executing this test.
+	// TODO: Fetch these values from the configuration file.
+	ccsRegion := "us-east-1"
+	ccsAccessKey := "example-access-key"
+	ccsSecretKey := "example-private-key"
+	ccsAccountID := "example-account-id"
+
 	targeter := func(t *vegeta.Target) error {
 		fakeClusterProps := map[string]string{
 			"fake_cluster": "true",
@@ -42,7 +49,14 @@ func generateCreateClusterTargeter(ID, method, url string) vegeta.Targeter {
 			Name(fmt.Sprintf("perf-%s-%d", id, idx)).
 			Properties(fakeClusterProps).
 			MultiAZ(true).
-			Region(v1.NewCloudRegion().ID(helpers.DefaultAWSRegion)).
+			Region(v1.NewCloudRegion().ID(ccsRegion)).
+			CCS(v1.NewCCS().Enabled(true)).
+			AWS(
+				v1.NewAWS().
+					AccessKeyID(ccsAccessKey).
+					SecretAccessKey(ccsSecretKey).
+					AccountID(ccsAccountID),
+			).
 			Build()
 		if err != nil {
 			return err

--- a/pkg/types/test_config.go
+++ b/pkg/types/test_config.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/cloud-bulldozer/ocm-api-load/pkg/logging"
 	sdk "github.com/openshift-online/ocm-sdk-go"
-	"github.com/spf13/viper"
 	vegeta "github.com/tsenart/vegeta/v12/lib"
 )
 
@@ -18,7 +17,6 @@ type TestConfiguration struct {
 	Cooldown        time.Duration
 	Rate            vegeta.Rate
 	Connection      *sdk.Connection
-	Viper           *viper.Viper
 	Logger          logging.Logger
 	Ctx             context.Context
 }


### PR DESCRIPTION
- CCS credential(s) can now be supplied and are used when executing the `create-cluster` test
- Configuration values can be fetched directly from Viper

