### PR TITLE
Ramp up

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,17 +39,27 @@ path as your binary, it will be autodetected and you could run by just calling i
 >> Default values don't count for precedence.
 
 ```
-      --config-file string     config file (default "config.yaml")
-      --duration int           Duration of each individual run in minutes. (default 1)
-      --cooldown int           Cooldown time between tests in seconds. (default 10 s)
-      --gateway-url string     Gateway url to perform the test against (default "https://api.integration.openshift.com")
-  -h, --help                   help for ocm-api-load
-      --ocm-token string       OCM Authorization token
-      --ocm-token-url string   Token URL (default "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token")
-      --output-path string     Output directory for result and report files (default "results")
-      --rate string            Rate of the attack. Format example 5/s. (Available units 'ns', 'us', 'ms', 's', 'm', 'h') (default "1/s")
-      --test-id string         Unique ID to identify the test run. UUID is recommended (default "dc049b1d-92b4-420c-9eb7-34f30229ef46")
-      --test-names strings     Names for the tests to be run. (default [all])
+      --aws-access-key string      AWS access key
+      --aws-access-secret string   AWS access secret
+      --aws-account-id string      AWS Account ID, is the 12-digit account number.
+      --aws-region string          AWS region (default "us-west-1")
+      --config-file string         config file (default "config.yaml")
+      --cooldown int               Cooldown time between tests in seconds. (default 10)
+      --duration int               Duration of each individual run in minutes. (default 1)
+      --end-rate int               Ending request per second rate. (E.g.: 5 would be 5 req/s)
+      --gateway-url string         Gateway url to perform the test against (default "https://api.integration.openshift.com")
+  -h, --help                       help for ocm-api-load
+      --ocm-token string           OCM Authorization token
+      --ocm-token-url string       Token URL (default "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token")
+      --output-path string         Output directory for result and report files (default "results")
+      --ramp-duration int          Duration of ramp in minutes, before normal execution. (default 0)
+      --ramp-steps int             Number of stepts to get from start rate to end rate. (Minimum 2 steps)
+      --ramp-type string           Type of ramp to use for all tests. (linear, exponential)
+      --rate string                Rate of the attack. Format example 5/s. (Available units 'ns', 'us', 'ms', 's', 'm', 'h') (default "1/s")
+      --start-rate int             Starting request per second rate. (E.g.: 5 would be 5 req/s)
+      --test-id string             Unique ID to identify the test run. UUID is recommended (default "c160dab1-7fa3-4965-9797-47da16e5c1b9")
+      --test-names strings         Names for the tests to be run.
+  -v, --verbose                    set this flag to activate verbose logging.
 ```
 
 ## Tests
@@ -60,12 +70,15 @@ path as your binary, it will be autodetected and you could run by just calling i
 | list-subscriptions | /api/accounts_mgmt/v1/subscriptions | GET |
 | access-review | /api/authorizations/v1/access_review | POST |
 | register-new-cluster | /api/accounts_mgmt/v1/cluster_registrations | POST |
+| register-existing-cluster | /api/accounts_mgmt/v1/cluster_registrations | POST |
 | create-cluster | /api/clusters_mgmt/v1/clusters | POST |
 | list-clusters | /api/clusters_mgmt/v1/clusters | GET |
 | get-current-account | /api/accounts_mgmt/v1/current_account | GET |
 | quota-cost | /api/accounts_mgmt/v1/organizations/{orgId}/quota_cost | GET |
 | resource-review | /api/authorizations/v1/resource_review | POST |
 | cluster-authorizations | /api/accounts_mgmt/v1/cluster_authorizations | POST |
+| self-terms-review | /api/authorizations/v1/self_terms_review | POST |
+| certificates | /api/accounts_mgmt/v1/certificates | POST |
 |--|--|--|
 
 ## Config file
@@ -83,6 +96,11 @@ path as your binary, it will be autodetected and you could run by just calling i
 - cooldown: Cooldown time between tests in seconds. (default 10 s)
 - rate: Rate of the attack. Format example 5/s. (Available units 'ns', 'us', 'ms', 's', 'm', 'h') (default "1/s")
 - test-id: Unique ID to identify the test run. UUID is recommended (default "dc049b1d-92b4-420c-9eb7-34f30229ef46")
+- ramp-type: Type of ramp to use for all tests. (linear, exponential)
+- ramp-duration: Duration of ramp in minutes, before normal execution. (default 0)
+- start-rate: Starting request per second rate. (E.g.: 5 would be 5 req/s)
+- end-rate: Ending request per second rate. (E.g.: 5 would be 5 req/s)
+- ramp-steps: Number of stepts to get from start rate to end rate. (Minimum 2 steps)
 - tests: List of the tests to run. Empty list means all.
 
 ### Test options
@@ -91,6 +109,31 @@ Each test can contain this options:
 
 - rate: Rate of the attack. Format example 5/s. (Available units 'ns', 'us', 'ms', 's', 'm', 'h') (default "1/s")
 - duration: Override duration for the test. (A positive integer accompanied of a valid unit)
+
+#### Ramping functionality
+
+Each test can have a specific configuration for ranmping up the rate, inthis case the following options must be provided.
+
+- duration: in minutes
+- ramp-type: Type of ramp to use for all tests. (linear, exponential)
+- ramp-duration: Duration of ramp in minutes, before normal execution. (default 0)
+- start-rate: Starting request per second rate. (E.g.: 5 would be 5 req/s)
+- end-rate: Ending request per second rate. (E.g.: 5 would be 5 req/s)
+- ramp-steps: Number of stepts to get from start rate to end rate. (Minimum 2 steps)
+
+> `rate` option is not needed for this.
+
+##### Example
+
+```yaml
+  cluster-authorizations:
+    duration: 30
+    ramp-type: exponential
+    ramp-duration: 10
+    start-rate: 1
+    end-rate: 50
+    ramp-steps: 6
+```
 
 ### Obligatory options
 
@@ -169,3 +212,47 @@ Steps:
 - Be sure you are in the latest version of `main` branch and have bumped the version
 
 - Now you are ready to run `make release` this will build the binary and generate the tarfiles that contain all the needed files
+
+## Ramping Up Theory
+
+The test will run a number <ramp-steps> with a running time of <duration>/<ramp-steps> rounded for each step, this can sometimes make the test last more or less than the expected duration, but we want to have a even distribution of times.
+
+As each step finishes it will increase the rate according to a delta that is calculated with the parameters:
+
+For both types of ramps we have common behaviour:
+
+- First rate: is always `start-rate`
+- Last rate: is always `end-rate`
+- Since we cannot use float values for rates, we round all the rates to it's closest integer.
+
+### For a linear ramp it will use this formula
+
+`delta = ( end-rate - start-rate ) / ( ramp-steps - 1 )`
+>ramp-steps, has always have to be greater than 1
+
+So the new rate will be:
+
+`newRate = oldRate + delta`
+
+### For an exponential distribution
+
+We are using the exponential formula `f(t)= x * <coeff> ^ t`
+
+the `coeff` is calculated with this formula
+
+`coeff = (end-rate / start-rate) ^ (1 / ramp-steps)`
+
+So the new rate will be:
+
+`newRate = start-rate * coeff ^ <# of step>`
+
+### `duration` vs `ramp-duration`
+
+The `duration` is the number of minutes the test is going to run. The `ramp-duration` is the number of minutes the ramp is going to last.
+
+- If `ramp-duration` is not set, the ramp will take the whole `duration`.
+- If `ramp-duration` is set, it will run the ramp for that long and then run the remaining of the `duration` at the `end-rate`.
+  - E.g.: if `duration` is 30 minutes and `ramp-duration` is 20 minutes. The test will run a ramp for 20 minutes and keep running at `end-rate` for the remaining 10 minutes. So it will run `end-rate` for `duration` - `ramp-duration` minutes.
+- If `ramp-duration` is greater than `duration` it will just perform a ramp for `ramp-duration` minutes.
+
+Overrides for the values work the same, localized test values take priority over global values.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -19,6 +19,10 @@ cooldown: 10
 output-path: "./results"
 rate: "5/s"
 test-id: new-test
+ramp-type: exponential
+start-rate: 1
+end-rate: 120
+ramp-steps: 6
 tests:
   self-access-token:
     rate: "1000/h"
@@ -51,11 +55,17 @@ tests:
     rate: "2000/h"
     duration: 1
   cluster-authorizations:
-    rate: "2000/h"
-    duration: 1
+    duration: 30
+    ramp-type: linear
+    start-rate: 1
+    end-rate: 50
+    ramp-steps: 6
   self-terms-review:
-    rate: "10/s"
-    duration: 1
+    duration: 30
+    ramp-type: exponential
+    start-rate: 1
+    end-rate: 50
+    ramp-steps: 6
   certificates:
     rate: "2/s"
     duration: 1

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,62 @@
+package config
+
+import (
+	"context"
+
+	"github.com/cloud-bulldozer/ocm-api-load/pkg/logging"
+	"github.com/spf13/viper"
+)
+
+type ConfigHelper struct {
+	logger logging.Logger
+	conf   *viper.Viper
+}
+
+func NewConfigHelper(logger logging.Logger, conf *viper.Viper) *ConfigHelper {
+	return &ConfigHelper{
+		logger: logger,
+		conf:   conf,
+	}
+}
+
+func (c *ConfigHelper) ResolveStringConfig(ctx context.Context, def, key string) string {
+	s := c.conf.GetString(key)
+	if s == "" {
+		c.logger.Info(ctx, "no value for %s. Using default value.", key)
+		return def
+	}
+	return s
+}
+
+func (c *ConfigHelper) ResolveIntConfig(ctx context.Context, def int, key string) int {
+	i := c.conf.GetInt(key)
+	if i == 0 {
+		c.logger.Info(ctx, "no value for %s. Using default value.", key)
+		return def
+	}
+	return i
+}
+
+func (c *ConfigHelper) ValidateRampConfig(ctx context.Context, max, min, steps int) bool {
+	if steps < 2 {
+		c.logger.Warn(ctx,
+			"steps must be always 2 or more. Ignoring ramping configuration.")
+		return false
+	}
+	if min < 1 {
+		c.logger.Warn(ctx,
+			"min rate must be always 1 or more. Ignoring ramping configuration.")
+		return false
+	}
+	if max < 1 {
+		c.logger.Warn(ctx,
+			"max rate must be always 1 or more. Ignoring ramping configuration.")
+		return false
+	}
+	if max <= min {
+		c.logger.Warn(ctx,
+			"max rate must be bigger than min rate. Ignoring ramping configuration.")
+		return false
+	}
+	return true
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,100 @@
+package config
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cloud-bulldozer/ocm-api-load/pkg/logging"
+	"github.com/spf13/viper"
+)
+
+func TestConfigHelper_ResolveStringConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		def  string
+		key  string
+		want string
+	}{
+		{"1", "NoName", "testName", "NoName"},
+		{"2", "NoName", "test_name", "MyTest"},
+		{"3", "5/s", "rate", "5/s"},
+		{"4", "5/s", "MyTest.rate", "2/s"},
+	}
+	conf := viper.New()
+	conf.Set("test_name", "MyTest")
+	conf.Set("MyTest", map[string]string{})
+	conf.Set("MyTest.rate", "2/s")
+	logBuilder := logging.NewGoLoggerBuilder()
+	log, _ := logBuilder.Build()
+	c := NewConfigHelper(log, conf)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := c.ResolveStringConfig(context.TODO(), tt.def, tt.key); got != tt.want {
+				t.Errorf("ConfigHelper.ResolveStringConfig() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConfigHelper_ResolveIntConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		def  int
+		key  string
+		want int
+	}{
+		{"1", 15, "testDuration", 15},
+		{"2", 15, "test_duration", 33},
+		{"3", 4, "duration", 4},
+		{"4", 4, "MyTest.duration", 99},
+	}
+	conf := viper.New()
+	conf.Set("test_duration", 33)
+	conf.Set("MyTest", map[string]interface{}{})
+	conf.Set("MyTest.duration", 99)
+	logBuilder := logging.NewGoLoggerBuilder()
+	log, _ := logBuilder.Build()
+	c := NewConfigHelper(log, conf)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := c.ResolveIntConfig(context.TODO(), tt.def, tt.key); got != tt.want {
+				t.Errorf("ConfigHelper.ResolveIntConfig() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConfigHelper_ValidateRampConfig(t *testing.T) {
+	tests := []struct {
+		name  string
+		min   int
+		max   int
+		steps int
+		want  bool
+	}{
+		{"1", 1, 5, 2, true},
+		{"2", 1, 5, 1, false},
+		{"3", 1, 5, 0, false},
+		{"4", 0, 5, 2, false},
+		{"4", 1, 0, 2, false},
+		{"4", 5, 5, 2, false},
+		{"4", 5, 2, 2, false},
+	}
+	conf := viper.New()
+	conf.Set("test_duration", 33)
+	conf.Set("MyTest", map[string]interface{}{})
+	conf.Set("MyTest.duration", 99)
+	logBuilder := logging.NewGoLoggerBuilder()
+	log, _ := logBuilder.Build()
+	c := &ConfigHelper{
+		logger: log,
+		conf:   conf,
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := c.ValidateRampConfig(context.TODO(), tt.max, tt.min, tt.steps); got != tt.want {
+				t.Errorf("ConfigHelper.ValidateRampConfig() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/helpers/clean_clusters_transport.go
+++ b/pkg/helpers/clean_clusters_transport.go
@@ -15,16 +15,16 @@ import (
 type CleanClustersTransport struct {
 	Wrapped http.RoundTripper
 	Logger  logging.Logger
-	Context context.Context
 }
 
 func (t *CleanClustersTransport) RoundTrip(request *http.Request) (*http.Response, error) {
 	var err error
 	manipulated := false
+	ctx := request.Context()
 	if t.isCreateCluster(request) {
 		request, manipulated, err = t.manipulateRequest(request)
 		if err != nil {
-			t.Logger.Error(t.Context, "Failed to manipulate request for cleanup: %v", err)
+			t.Logger.Error(ctx, "Failed to manipulate request for cleanup: %v", err)
 		}
 	}
 	response, err := t.Wrapped.RoundTrip(request)
@@ -41,54 +41,57 @@ func (t *CleanClustersTransport) RoundTrip(request *http.Request) (*http.Respons
 }
 
 func (t *CleanClustersTransport) addToCleanup(request *http.Request, response *http.Response) *http.Response {
+	ctx := request.Context()
 	body, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		t.Logger.Error(t.Context, "Failed to read body of response for request %s %s: %v", request.Method,
+		t.Logger.Error(ctx, "Failed to read body of response for request %s %s: %v", request.Method,
 			request.URL.String(), err)
 		return response
 	}
 	var cluster map[string]interface{}
 	err = json.Unmarshal(body, &cluster)
 	if err != nil {
-		t.Logger.Error(t.Context, "Failed to unmarshal body of response for request %s %s: %v", request.Method,
+		t.Logger.Error(ctx, "Failed to unmarshal body of response for request %s %s: %v", request.Method,
 			request.URL.String(), err)
 		return response
 	}
 	clusterID, ok := cluster["id"]
 	if !ok {
-		t.Logger.Error(t.Context, "Failed to get cluster ID from body of response for request %s %s: %v", request.Method,
+		t.Logger.Error(ctx, "Failed to get cluster ID from body of response for request %s %s: %v", request.Method,
 			request.URL.String(), err)
 		return response
 	}
 
-	markClusterForCleanup(clusterID.(string), true, t.Logger, t.Context)
+	markClusterForCleanup(ctx, clusterID.(string), true, t.Logger)
 	response.Body = ioutil.NopCloser(strings.NewReader(string(body)))
 	return response
 }
 
 func (t *CleanClustersTransport) removeFromCleanup(request *http.Request) {
+	ctx := request.Context()
 	urlParts := strings.Split(request.URL.String(), "?")
 	url := urlParts[0]
 	parts := strings.Split(url, "/")
 	clusterID := parts[len(parts)-1]
-	t.Logger.Info(t.Context, "Removing cluster '%s' from cleanup", clusterID)
+	t.Logger.Info(ctx, "Removing cluster '%s' from cleanup", clusterID)
 	delete(createdClusterIDs, clusterID)
 }
 
 func (t *CleanClustersTransport) manipulateRequest(request *http.Request) (*http.Request, bool, error) {
+	ctx := request.Context()
 	body, err := ioutil.ReadAll(request.Body)
 	if err != nil {
-		t.Logger.Error(t.Context, "Failed to read body of cluster for request %s %s: %v",
+		t.Logger.Error(ctx, "Failed to read body of cluster for request %s %s: %v",
 			request.Method, request.URL.String(), err)
 		return request, false, err
 	}
 	newBody, err := addTestProperties(string(body))
 	if err != nil {
-		t.Logger.Error(t.Context, "Failed to add test properties to cluster for request %s %s: %v",
+		t.Logger.Error(ctx, "Failed to add test properties to cluster for request %s %s: %v",
 			request.Method, request.URL.String(), err)
 		return request, false, err
 	}
-	t.Logger.Info(t.Context, "%s %s: %s", request.Method, request.URL.String(), newBody)
+	t.Logger.Info(ctx, "%s %s: %s", request.Method, request.URL.String(), newBody)
 	request.Body = ioutil.NopCloser(strings.NewReader(newBody))
 	request.ContentLength = int64(len(newBody))
 	return request, true, nil
@@ -104,7 +107,7 @@ func (t *CleanClustersTransport) isDeleteCluster(request *http.Request) bool {
 	return parts[len(parts)-2] == "clusters" && request.Method == "DELETE"
 }
 
-func markClusterForCleanup(clusterID string, deprovision bool, logger logging.Logger, ctx context.Context) {
+func markClusterForCleanup(ctx context.Context, clusterID string, deprovision bool, logger logging.Logger) {
 	logger.Info(ctx, "Marking cluster '%s' for cleanup with 'deprovision'=%v", clusterID, deprovision)
 	createdClusterIDs[clusterID] = deprovision
 }

--- a/pkg/helpers/connection.go
+++ b/pkg/helpers/connection.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"net/http"
 
-	sdk "github.com/openshift-online/ocm-sdk-go"
 	"github.com/cloud-bulldozer/ocm-api-load/pkg/logging"
+	sdk "github.com/openshift-online/ocm-sdk-go"
 )
 
 // BuildConnection build the vegeta connection
 // that is going to be used for testing
-func BuildConnection(gateway, clientID, clientSecret, token string, logger logging.Logger, ctx context.Context) (*sdk.Connection, error) {
+func BuildConnection(ctx context.Context, gateway, clientID, clientSecret, token string, logger logging.Logger) (*sdk.Connection, error) {
 	conn, err := sdk.NewConnectionBuilder().
 		Insecure(true).
 		URL(gateway).
@@ -18,7 +18,7 @@ func BuildConnection(gateway, clientID, clientSecret, token string, logger loggi
 		Tokens(token).
 		Logger(logger).
 		TransportWrapper(func(wrapped http.RoundTripper) http.RoundTripper {
-			return &CleanClustersTransport{Wrapped: wrapped, Logger: logger, Context: ctx}
+			return &CleanClustersTransport{Wrapped: wrapped, Logger: logger}
 		}).
 		BuildContext(ctx)
 	if err != nil {

--- a/pkg/helpers/file_system.go
+++ b/pkg/helpers/file_system.go
@@ -10,8 +10,8 @@ import (
 )
 
 // CreateFolder creates folder in the system
-func CreateFolder(path string, logger logging.Logger) error {
-	logger.Info(context.Background(), "Creating '%s' directory", path)
+func CreateFolder(ctx context.Context, path string, logger logging.Logger) error {
+	logger.Info(ctx, "Creating '%s' directory", path)
 	folder, err := filepath.Abs(path)
 	if err != nil {
 		return err

--- a/pkg/ramping/exponential.go
+++ b/pkg/ramping/exponential.go
@@ -1,0 +1,41 @@
+package ramping
+
+import "math"
+
+type Exponential struct {
+	startRate   int
+	endRate     int
+	steps       int
+	currentRate float64
+	currentStep int
+	delta       float64
+}
+
+func NewExponentialRamp(startRate, endRate, steps int) *Exponential {
+	d := math.Pow((float64(endRate) / float64(startRate)), (1 / float64(steps)))
+	return &Exponential{
+		startRate:   startRate,
+		endRate:     endRate,
+		steps:       steps,
+		currentStep: 1,
+		currentRate: float64(startRate),
+		delta:       d,
+	}
+}
+
+func (e *Exponential) NextRate() int {
+	if e.currentStep == e.steps {
+		return int(e.endRate)
+	}
+	e.currentRate = float64(e.startRate) * math.Pow(e.delta, float64(e.currentStep))
+	e.currentStep += 1
+	return int(math.Round(e.currentRate))
+}
+
+func (e *Exponential) GetSteps() int {
+	return int(e.steps)
+}
+
+func (e *Exponential) GetType() string {
+	return "Exponential ramp"
+}

--- a/pkg/ramping/exponential_test.go
+++ b/pkg/ramping/exponential_test.go
@@ -1,0 +1,71 @@
+package ramping
+
+import (
+	"testing"
+)
+
+func TestExponential_NextRate_scenario1(t *testing.T) {
+	e := NewExponentialRamp(2, 20, 8)
+	tests := []struct {
+		name string
+		want int
+	}{
+		{"step1", 3},
+		{"step2", 4},
+		{"step3", 5},
+		{"step4", 6},
+		{"step5", 8},
+		{"step6", 11},
+		{"step7", 15},
+		{"step8", 20},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := e.NextRate(); got != tt.want {
+				t.Errorf("Exponential.NextRate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExponential_NextRate_scenario2(t *testing.T) {
+	e := NewExponentialRamp(1, 100, 8)
+	tests := []struct {
+		name string
+		want int
+	}{
+		{"step1", 2},
+		{"step2", 3},
+		{"step3", 6},
+		{"step4", 10},
+		{"step5", 18},
+		{"step6", 32},
+		{"step7", 56},
+		{"step8", 100},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := e.NextRate(); got != tt.want {
+				t.Errorf("Exponential.NextRate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExponential_GetSteps(t *testing.T) {
+	t.Run("testing GetSteps", func(t *testing.T) {
+		e := NewExponentialRamp(1, 10, 5)
+		if got := e.GetSteps(); got != 5 {
+			t.Errorf("Exponential.GetSteps() = %v, want %v", got, 5)
+		}
+	})
+}
+
+func TestExponential_GetType(t *testing.T) {
+	t.Run("testing GetType", func(t *testing.T) {
+		e := NewExponentialRamp(1, 10, 5)
+		if got := e.GetType(); got != "Exponential ramp" {
+			t.Errorf("Exponential.GetType() = %v, want %v", got, "Exponential ramp")
+		}
+	})
+}

--- a/pkg/ramping/linear.go
+++ b/pkg/ramping/linear.go
@@ -1,0 +1,45 @@
+package ramping
+
+import (
+	"math"
+)
+
+type Linear struct {
+	startRate   int
+	endRate     int
+	steps       int
+	currentRate float64
+	currentStep int
+	delta       float64
+}
+
+func NewLinearRamp(startRate, endRate, steps int) *Linear {
+	d := float64(endRate-startRate) / float64(steps-1)
+	return &Linear{
+		startRate:   startRate,
+		endRate:     endRate,
+		steps:       steps,
+		currentStep: 1,
+		currentRate: float64(startRate),
+		delta:       d,
+	}
+}
+
+func (l *Linear) NextRate() int {
+	if l.currentStep == l.steps {
+		return int(l.endRate)
+	}
+	if l.currentStep != 1 {
+		l.currentRate = l.currentRate + l.delta
+	}
+	l.currentStep += 1
+	return int(math.Round(l.currentRate))
+}
+
+func (l *Linear) GetSteps() int {
+	return int(l.steps)
+}
+
+func (l *Linear) GetType() string {
+	return "Linear ramp"
+}

--- a/pkg/ramping/linear_test.go
+++ b/pkg/ramping/linear_test.go
@@ -1,0 +1,96 @@
+package ramping
+
+import (
+	"testing"
+)
+
+func TestLinear_NextRate_scenario1(t *testing.T) {
+	l := NewLinearRamp(2, 50, 6)
+	tests := []struct {
+		name string
+		want int
+	}{
+		{"step1", 2},
+		{"step2", 12},
+		{"step3", 21},
+		{"step4", 31},
+		{"step5", 40},
+		{"step6", 50},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := l.NextRate(); got != tt.want {
+				t.Errorf("Linear.NextRate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLinear_NextRate_scenario2(t *testing.T) {
+	l := NewLinearRamp(1, 15, 9)
+	tests := []struct {
+		name string
+		want int
+	}{
+		{"step1", 1},
+		{"step2", 3},
+		{"step3", 5},
+		{"step4", 6},
+		{"step5", 8},
+		{"step6", 10},
+		{"step7", 12},
+		{"step8", 13},
+		{"step9", 15},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := l.NextRate(); got != tt.want {
+				t.Errorf("Linear.NextRate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLinear_NextRate_scenario3(t *testing.T) {
+	l := NewLinearRamp(1, 10, 10)
+	tests := []struct {
+		name string
+		want int
+	}{
+		{"step1", 1},
+		{"step2", 2},
+		{"step3", 3},
+		{"step4", 4},
+		{"step5", 5},
+		{"step6", 6},
+		{"step7", 7},
+		{"step8", 8},
+		{"step9", 9},
+		{"step10", 10},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := l.NextRate(); got != tt.want {
+				t.Errorf("Linear.NextRate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLinear_GetSteps(t *testing.T) {
+	t.Run("testing GetSteps", func(t *testing.T) {
+		l := NewLinearRamp(1, 10, 7)
+		if got := l.GetSteps(); got != 7 {
+			t.Errorf("Linear.GetSteps() = %v, want %v", got, 7)
+		}
+	})
+}
+
+func TestLinear_GetType(t *testing.T) {
+	t.Run("testing GetType", func(t *testing.T) {
+		l := NewLinearRamp(1, 10, 7)
+		if got := l.GetType(); got != "Linear ramp" {
+			t.Errorf("Linear.GetType() = %v, want %v", got, "Linear ramp")
+		}
+	})
+}

--- a/pkg/ramping/ramper.go
+++ b/pkg/ramping/ramper.go
@@ -1,0 +1,27 @@
+package ramping
+
+type RampType int64
+
+const (
+	LinearRamp RampType = iota
+	ExponentialRamp
+)
+
+type Ramper interface {
+	NextRate() int
+	GetSteps() int
+	GetType() string
+}
+
+// NewRampingService when using None ramping
+// send the rate in the minRate it will be the used
+// to initialize NoneRamp
+func NewRampingService(rampType RampType, startRate, endRate, steps int) Ramper {
+	switch rampType {
+	case LinearRamp:
+		return NewLinearRamp(startRate, endRate, steps)
+	case ExponentialRamp:
+		return NewExponentialRamp(startRate, endRate, steps)
+	}
+	return nil
+}

--- a/pkg/ramping/ramper_test.go
+++ b/pkg/ramping/ramper_test.go
@@ -1,0 +1,28 @@
+package ramping
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNewRampingService(t *testing.T) {
+	tests := []struct {
+		name      string
+		rampType  RampType
+		startRate int
+		endRate   int
+		steps     int
+		want      Ramper
+	}{
+		{"Linear", LinearRamp, 2, 10, 4, NewLinearRamp(2, 10, 4)},
+		{"Exponential", ExponentialRamp, 2, 10, 4, NewExponentialRamp(2, 10, 4)},
+		{"Error", 2, 2, 10, 4, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewRampingService(tt.rampType, tt.startRate, tt.endRate, tt.steps); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewRampingService() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/tests/handlers/clusters.go
+++ b/pkg/tests/handlers/clusters.go
@@ -13,10 +13,10 @@ import (
 	vegeta "github.com/tsenart/vegeta/v12/lib"
 )
 
-func TestCreateCluster(options *types.TestOptions) error {
+func TestCreateCluster(ctx context.Context, options *types.TestOptions) error {
 
 	testName := options.TestName
-	targeter := generateCreateClusterTargeter(options.ID, options.Method, options.Path, options.Context, options.Logger)
+	targeter := generateCreateClusterTargeter(ctx, options.ID, options.Method, options.Path, options.Logger)
 
 	for res := range options.Attacker.Attack(targeter, options.Rate, options.Duration, testName) {
 		options.Encoder.Encode(res)
@@ -28,7 +28,7 @@ func TestCreateCluster(options *types.TestOptions) error {
 // Generates a targeter for the "POST /api/clusters_mgmt/v1/clusters" endpoint
 // with monotonic increasing indexes.
 // The clusters created are "fake clusters", that is, do not consume any cloud-provider infrastructure.
-func generateCreateClusterTargeter(ID, method, url string, ctx context.Context, log logging.Logger) vegeta.Targeter {
+func generateCreateClusterTargeter(ctx context.Context, ID, method, url string, log logging.Logger) vegeta.Targeter {
 	idx := 0
 
 	// This will take the first 4 characters of the UUID

--- a/pkg/tests/handlers/static.go
+++ b/pkg/tests/handlers/static.go
@@ -1,11 +1,13 @@
 package handlers
 
 import (
+	"context"
+
 	"github.com/cloud-bulldozer/ocm-api-load/pkg/types"
 	vegeta "github.com/tsenart/vegeta/v12/lib"
 )
 
-func TestStaticEndpoint(options *types.TestOptions) error {
+func TestStaticEndpoint(ctx context.Context, options *types.TestOptions) error {
 
 	// Specify the HTTP request(s) that will be executed
 	target := vegeta.Target{

--- a/pkg/tests/run.go
+++ b/pkg/tests/run.go
@@ -1,19 +1,50 @@
 package tests
 
 import (
+	"context"
 	"fmt"
+	"math"
 	"net/http"
 	"time"
 
+	"github.com/cloud-bulldozer/ocm-api-load/pkg/config"
 	"github.com/cloud-bulldozer/ocm-api-load/pkg/helpers"
-	"github.com/cloud-bulldozer/ocm-api-load/pkg/types"
+	"github.com/cloud-bulldozer/ocm-api-load/pkg/logging"
+	ramp "github.com/cloud-bulldozer/ocm-api-load/pkg/ramping"
+	sdk "github.com/openshift-online/ocm-sdk-go"
 	"github.com/spf13/viper"
 	vegeta "github.com/tsenart/vegeta/v12/lib"
 )
 
-func Run(tc types.TestConfiguration) error {
-	logger := tc.Logger
+// Runner prepares config and runs tests
+type Runner struct {
+	connection      *sdk.Connection
+	logger          logging.Logger
+	outputDirectory string
+	testID          string
+}
+
+func NewRunner(testID, outputDirectory string, logger logging.Logger, conn *sdk.Connection) *Runner {
+	return &Runner{
+		connection:      conn,
+		logger:          logger,
+		outputDirectory: outputDirectory,
+		testID:          testID,
+	}
+}
+
+func (r *Runner) Run(ctx context.Context) error {
+	duration := viper.GetInt("duration")
+	cooldown := viper.GetInt("cooldown")
+	rate := viper.GetString("rate")
+	rampType := viper.GetString("ramp-type")
+	startRate := viper.GetInt("start-rate")
+	endRate := viper.GetInt("end-rate")
+	rampSteps := viper.GetInt("ramp-steps")
+	rampDuration := viper.GetInt("ramp-duration")
+
 	tests_conf := viper.Sub("tests")
+	confHelper := config.NewConfigHelper(r.logger, tests_conf)
 	for i, t := range tests {
 		// Check if the test is set to run
 		if !tests_conf.InConfig(t.TestName) && !tests_conf.InConfig("all") {
@@ -23,72 +54,110 @@ func Run(tc types.TestConfiguration) error {
 		// Create an Attacker for each individual test. This is due to the
 		// fact that vegeta (and compatible parsers, such as benchmark-wrapper)
 		// expect the sequence to start at 0 for each result file. (Possibly a bug?)
-		connAttacker := vegeta.Client(&http.Client{Transport: tc.Connection})
+		connAttacker := vegeta.Client(&http.Client{Transport: r.connection})
 		attacker := vegeta.NewAttacker(connAttacker)
 
 		// Open a file and create an encoder that will be used to store the
 		// results for each test.
-		fileName := fmt.Sprintf("%s_%s.json", tc.TestID, t.TestName)
-		resultsFile, err := helpers.CreateFile(fileName, tc.OutputDirectory)
+		fileName := fmt.Sprintf("%s_%s.json", r.testID, t.TestName)
+		resultsFile, err := helpers.CreateFile(fileName, r.outputDirectory)
 		if err != nil {
 			return err
 		}
 		encoder := vegeta.NewJSONEncoder(resultsFile)
 
 		// Bind "Test Harness"
-		t.ID = tc.TestID
+		t.ID = r.testID
 		t.Attacker = attacker
-		t.Connection = tc.Connection
+		t.Connection = r.connection
 		t.Encoder = &encoder
-		t.Logger = logger
-		t.Context = tc.Ctx
+		t.Logger = r.logger
 
 		// Create the vegeta rate with the config values
-		current_test_rate := tests_conf.GetString(fmt.Sprintf("%s.rate", t.TestName))
-		if current_test_rate == "" {
-			logger.Info(tc.Ctx, "no specific rate for test %s. Using default", t.TestName)
-			t.Rate = tc.Rate
-		} else {
-			r, err := helpers.ParseRate(current_test_rate)
-			if err != nil {
-				logger.Warn(tc.Ctx,
-					"error parsing rate for test %s: %s. Using default",
-					t.TestName,
-					current_test_rate)
-				t.Rate = tc.Rate
-			} else {
-				t.Rate = r
+		currentTestRate := confHelper.ResolveStringConfig(ctx, rate, fmt.Sprintf("%s.rate", t.TestName))
+		rate, err := helpers.ParseRate(currentTestRate)
+		if err != nil {
+			r.logger.Warn(ctx,
+				"error parsing rate for test %s: %s. Using default",
+				t.TestName,
+				currentTestRate)
+		}
+		t.Rate = rate
+
+		// Check for an override on the test duration
+		currentTestDuration := confHelper.ResolveIntConfig(ctx, duration, fmt.Sprintf("%s.duration", t.TestName))
+		t.Duration = time.Duration(currentTestDuration) * time.Minute
+
+		var ramper ramp.Ramper
+		currentRampDuration := 0
+		remainingDuration := 0
+		currentTestRamp := confHelper.ResolveStringConfig(ctx, rampType, fmt.Sprintf("%s.ramp-type", t.TestName))
+		if currentTestRamp != "" {
+			currentStartRate := confHelper.ResolveIntConfig(ctx, startRate, fmt.Sprintf("%s.start-rate", t.TestName))
+			currentEndRate := confHelper.ResolveIntConfig(ctx, endRate, fmt.Sprintf("%s.end-rate", t.TestName))
+			currentSteps := confHelper.ResolveIntConfig(ctx, rampSteps, fmt.Sprintf("%s.ramp-steps", t.TestName))
+			currentRampDuration = confHelper.ResolveIntConfig(ctx, rampDuration, fmt.Sprintf("%s.ramp-duration", t.TestName))
+			r.logger.Info(ctx, "Validating Ramp configuration for test %s", t.TestName)
+			if !confHelper.ValidateRampConfig(ctx, currentStartRate, currentEndRate, currentSteps) {
+				currentTestRamp = ""
+			}
+			switch currentTestRamp {
+			case "linear":
+				ramper = ramp.NewRampingService(ramp.LinearRamp, currentStartRate, currentEndRate, currentSteps)
+			case "exponential":
+				ramper = ramp.NewRampingService(ramp.ExponentialRamp, currentStartRate, currentEndRate, currentSteps)
 			}
 		}
 
-		// Check for an override on the test duration
-		dur := tests_conf.GetInt(fmt.Sprintf("%s.duration", t.TestName))
-		if dur == 0 {
-			// Using default
-			t.Duration = tc.Duration
+		if ramper == nil {
+			r.logger.Info(ctx, "Executing Test: %s", t.TestName)
+			r.logger.Info(ctx, "Rate: %s", t.Rate.String())
+			r.logger.Info(ctx, "Duration: %s", t.Duration.String())
+			r.logger.Info(ctx, "Endpoint: %s", t.Path)
+			err = t.Handler(ctx, &t)
+			if err != nil {
+				return err
+			}
 		} else {
-			t.Duration = time.Duration(dur) * time.Minute
-		}
+			r.logger.Info(ctx, "Executing Test: %s", t.TestName)
+			r.logger.Info(ctx, "Ramp type: %s", ramper.GetType())
+			r.logger.Info(ctx, "Endpoint: %s", t.Path)
+			if currentRampDuration == 0 {
+				duration := math.Round(t.Duration.Minutes() / float64(ramper.GetSteps()))
+				t.Duration = time.Duration(duration) * time.Minute
+			} else {
+				remainingDuration = int(t.Duration.Minutes()) - currentRampDuration
+				duration := math.Round(float64(currentRampDuration) / float64(ramper.GetSteps()))
+				t.Duration = time.Duration(duration) * time.Minute
+			}
 
-		logger.Info(tc.Ctx, "Executing Test: %s", t.TestName)
-		logger.Info(tc.Ctx, "Rate: %s", t.Rate.String())
-		logger.Info(tc.Ctx, "Duration: %s", t.Duration.String())
-		logger.Info(tc.Ctx, "Endpoint: %s", t.Path)
-		err = t.Handler(&t)
-		if err != nil {
-			return err
+			for i := 0; i < ramper.GetSteps(); i++ {
+				r.logger.Info(ctx, "Ramping up... step %v", i+1)
+				rateInt := ramper.NextRate()
+				newRate, _ := helpers.ParseRate(fmt.Sprint(rateInt))
+				t.Rate = newRate
+				if i+1 == ramper.GetSteps() && remainingDuration > 0 {
+					t.Duration = t.Duration + (time.Duration(remainingDuration) * time.Minute)
+				}
+				r.logger.Info(ctx, "Rate: %s", t.Rate.String())
+				r.logger.Info(ctx, "Duration: %s", t.Duration.String())
+				err = t.Handler(ctx, &t)
+				if err != nil {
+					return err
+				}
+			}
 		}
 
 		// Cleanup (cannot defer as it must happen for each test in the loop)
-		logger.Info(tc.Ctx, "Results written to: %s", fileName)
+		r.logger.Info(ctx, "Results written to: %s", fileName)
 		err = resultsFile.Close()
 		if err != nil {
 			return err
 		}
 
-		if i+1 < len(tests_conf.AllSettings()) {
-			logger.Info(tc.Ctx, "Cooling down for next test for: %v s", tc.Cooldown.Seconds())
-			time.Sleep(tc.Cooldown)
+		if i < len(tests_conf.AllSettings()) {
+			r.logger.Info(ctx, "Cooling down for next test for: %v s", cooldown)
+			time.Sleep(time.Duration(cooldown) * time.Second)
 		}
 	}
 	return nil

--- a/pkg/types/test_config.go
+++ b/pkg/types/test_config.go
@@ -1,22 +1,14 @@
 package types
 
 import (
-	"context"
 	"time"
 
-	"github.com/cloud-bulldozer/ocm-api-load/pkg/logging"
-	sdk "github.com/openshift-online/ocm-sdk-go"
 	vegeta "github.com/tsenart/vegeta/v12/lib"
 )
 
 // TestConfiguration
 type TestConfiguration struct {
-	TestID          string
-	OutputDirectory string
-	Duration        time.Duration
-	Cooldown        time.Duration
-	Rate            vegeta.Rate
-	Connection      *sdk.Connection
-	Logger          logging.Logger
-	Ctx             context.Context
+	Duration time.Duration
+	Cooldown time.Duration
+	Rate     vegeta.Rate
 }

--- a/pkg/types/test_options.go
+++ b/pkg/types/test_options.go
@@ -24,11 +24,10 @@ type TestOptions struct {
 	Duration time.Duration
 
 	// Test "Infrastructure"
-	ID         string                         // Unique UUID of a given test-suite execution.
-	Handler    func(*TestOptions) (err error) // Function which tests the given endpoint
+	ID         string                                          // Unique UUID of a given test-suite execution.
+	Handler    func(context.Context, *TestOptions) (err error) // Function which tests the given endpoint
 	Attacker   *vegeta.Attacker
 	Connection *sdk.Connection
 	Encoder    *vegeta.Encoder // Encodes results and writes them to a File
 	Logger     logging.Logger
-	Context    context.Context
 }


### PR DESCRIPTION
# Description

Adding ramp up functionality to the suite.

Each individual test can be provided with the following parameters:

- duration: in minutes
- ramp-type: can be exponential or linear
- start-rate: as in req per second
- end-rate: as in req per second
- ramp-steps: Number of steps to reach the desired end-rate

The test will run # <steps> with a running time of <duration>/<steps> rounded, as each step finishes it will increase the rate according to a delta that is calculated with the parameters:

## For a linear ramp it will use this formula

`delta = ( end-rate - start-rate ) / ( steps - 1 )`
>steps, has always have to be greater than 1

So the new rate will be:

`newRate = oldRate + delta`

## For an exponential distribution:

We are using the exponential formula `f(t)=start-rate * <coeff> ^ t`

the `coeff` is calculated with this formula

`coeff = (end-rate / start-rate) ^ (1 / steps)`

So the new rate will be:

`newRate = start-rate * coeff ^ <# of step>`

### Tasks

- [x] Linear ramp
- [x] Exponential ramp
- [x] Implement usage
- [x] Implement flag options
- [x] Documentation
- [x] Automation tasks
  - [x] Cumulative Avg over time graph
  - [x] Request count over time graph

