### PR TITLE
add version to each ES doc

### DIFF
--- a/pkg/elastic/document.go
+++ b/pkg/elastic/document.go
@@ -16,4 +16,5 @@ type doc struct {
 	URL       string    `json:"url"`
 	HasError  bool      `json:"has_error"`
 	HasBody   bool      `json:"has_body"`
+	Version   string    `json:"version"`
 }

--- a/pkg/elastic/elastic.go
+++ b/pkg/elastic/elastic.go
@@ -8,8 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-        "strings"
-        "crypto/tls"
+	"crypto/tls"
 	"net/http"
 
 	"github.com/cloud-bulldozer/ocm-api-load/pkg/logging"
@@ -71,19 +70,7 @@ func newBulkIndexer(ctx context.Context, logger logging.Logger) (opensearchutil.
 	return bulkIndexer, nil
 }
 
-func (in *ESIndexer) IndexServerVersion(ctx context.Context, testID string, version string, testName string, logger logging.Logger) error {
-
-	err := in.BulkIndexer.Add(ctx, opensearchutil.BulkIndexerItem{
-		Body:   strings.NewReader(fmt.Sprintf(`{"version":"%s", "uuid":"%s", "attack":"%s"}`, version, testID, testName)),
-		Action: "index",
-	})
-	if err != nil {
-		return fmt.Errorf("BulkIndexer Error: %s", err)
-	}
-	return nil
-}
-
-func (in *ESIndexer) IndexFile(ctx context.Context, testID string, fileName string, logger logging.Logger) error {
+func (in *ESIndexer) IndexFile(ctx context.Context, testID string, version string, fileName string, logger logging.Logger) error {
 	file, err := os.Open(fileName)
 	if err != nil {
 		return err
@@ -131,6 +118,7 @@ func (in *ESIndexer) IndexFile(ctx context.Context, testID string, fileName stri
 			_doc.HasBody = true
 		}
 		_doc.Uuid = testID
+		_doc.Version = version
 		m, err := json.Marshal(_doc)
 		if err != nil {
 			errors = fmt.Sprintf("%s\n%s", errors, err)

--- a/pkg/elastic/elastic_test.go
+++ b/pkg/elastic/elastic_test.go
@@ -23,6 +23,7 @@ const (
 	OKFileContentRetunrnError = `{"attack":"access-review","seq":0,"code":300,"timestamp":"2022-03-17T17:12:32.077719034+01:00","latency":788624775,"bytes_out":0,"bytes_in":0,"error":"","body":"Hello World","method":"POST","url":"/api/authorizations/v1/access_review","headers":null}`
 	ErrorFileContent          = `{"attack":"access-review","seq":0,"code":200,"timestamp":"2022-03-17T17:12:32.077719034+01:00","latency":788624775,"bytes_out":0,"bytes_in":0,"error":"","body":"Hello World","method":"POST","url":"/api/authorizations/v1/access_review",`
 	TetsID                    = "4059b202-dc97-4473-9b90-b8bc0e14be1b"
+	Version                   = "version1"
 )
 
 func initConfig() {
@@ -89,6 +90,7 @@ func TestIndexFile(t *testing.T) {
 		_doc.HasBody = true
 	}
 	_doc.Uuid = TetsID
+	_doc.Version = Version
 	OKFileContentWithError, _ := json.Marshal(_doc)
 
 	mock.EXPECT().Add(ctx, gomock.Eq(
@@ -109,6 +111,7 @@ func TestIndexFile(t *testing.T) {
 		_doc.HasBody = true
 	}
 	_doc.Uuid = TetsID
+	_doc.Version = Version
 	OKFileContentNoError, _ := json.Marshal(_doc)
 
 	mock.EXPECT().Add(ctx, gomock.Eq(
@@ -129,6 +132,7 @@ func TestIndexFile(t *testing.T) {
 		_doc.HasBody = true
 	}
 	_doc.Uuid = TetsID
+	_doc.Version = Version
 	OKFileContentRetunrnError, _ := json.Marshal(_doc)
 
 	mock.EXPECT().Add(ctx, gomock.Eq(
@@ -148,19 +152,20 @@ func TestIndexFile(t *testing.T) {
 	tests := []struct {
 		name     string
 		testID   string
+		version  string
 		fileName string
 		wantErr  bool
 	}{
-		{"OKFileContentWithError", TetsID, testfile001, false},
-		{"OKFileContentNoError", TetsID, testfile002, false},
-		{"OKFileContentNoError", TetsID, testfile003, true},
-		{"ErrorFileContent", TetsID, testfile004, true},
-		{"FileDoesNotExist", TetsID, path.Join("tmp", "filename.txt"), true},
+		{"OKFileContentWithError", TetsID, Version, testfile001, false},
+		{"OKFileContentNoError", TetsID, Version, testfile002, false},
+		{"OKFileContentNoError", TetsID, Version, testfile003, true},
+		{"ErrorFileContent", TetsID, Version, testfile004, true},
+		{"FileDoesNotExist", TetsID, Version, path.Join("tmp", "filename.txt"), true},
 	}
 	for _, tt := range tests {
 
 		t.Run(tt.name, func(t *testing.T) {
-			if err := indexer.IndexFile(ctx, tt.testID, tt.fileName, logger); (err != nil) != tt.wantErr {
+			if err := indexer.IndexFile(ctx, tt.testID, tt.version, tt.fileName, logger); (err != nil) != tt.wantErr {
 				t.Errorf("IndexFile() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/pkg/tests/run.go
+++ b/pkg/tests/run.go
@@ -164,11 +164,7 @@ func (r *Runner) Run(ctx context.Context) error {
 			}
 	                serverVersion := helpers.GetServerVersion(ctx, r.connection)
 	                r.logger.Info(ctx, "server version %s", serverVersion)
-			err = indexer.IndexServerVersion(ctx, r.testID, serverVersion, t.TestName, r.logger)
-			if err != nil {
-				r.logger.Error(ctx, "Error during ES indexing: %s", err)
-			}
-			err = indexer.IndexFile(ctx, r.testID, resultsFile.Name(), r.logger)
+			err = indexer.IndexFile(ctx, r.testID, serverVersion, resultsFile.Name(), r.logger)
 			if err != nil {
 				r.logger.Error(ctx, "Error during ES indexing: %s", err)
 			}


### PR DESCRIPTION
Earlier we are pushing the version as a separate ES document.
This is not helpful for comparing api results based on version in
grafana dashboard. So we are now adding version to each ES
document.

An example ES doc with version looks like below
https://perf-results-kibana.apps.observability.perfscale.devcluster.openshift.com/app/discover#/doc/d0903d00-bbf8-11ec-a458-7d128bdee616/ocm-request-test?id=kLrcbIABs_qA3fnX_5D0

### Description

### Fixes
