### PR TITLE
ocm-api-data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,4 +39,4 @@ jobs:
       - name: flake8 Lint
         uses: py-actions/flake8@v1
         with:
-          path: "restructure_file.py","ES_Upload.py"
+          path: "automation.py ./hack/restructure_file.py ./hack/ES_Upload.py"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           requirements: requirements.txt
       - name: flake8 Lint
-        uses: py-actions/flake8@v1
+        uses: py-actions/flake8@v2
         with:
+          max-line-length: "100"
           path: "automation.py ./hack/restructure_file.py ./hack/ES_Upload.py"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,4 +39,4 @@ jobs:
       - name: flake8 Lint
         uses: py-actions/flake8@v1
         with:
-          path: "automation.py"
+          path: "restructure_file.py","ES_Upload.py"

--- a/hack/ES_Upload.py
+++ b/hack/ES_Upload.py
@@ -1,0 +1,72 @@
+from opensearchpy import OpenSearch
+import json
+import sys
+
+def payload_constructor(data,action):
+    action_string = json.dumps(action) + "\n"
+
+    payload_string=""
+    count=0
+    for line in data:
+        payload_string += action_string
+        this_line = json.dumps(line) + "\n"
+        payload_string += this_line
+        count+=1
+        if count == 100:
+          response=client.bulk(body=payload_string,index="ocm-api-data")
+          print(response)
+          count=0
+          payload_string=""
+        
+    return payload_string
+
+
+
+filename= sys.argv[1]
+
+
+
+# Create the client with SSL/TLS enabled, but hostname verification disabled.
+client = OpenSearch(
+    hosts = [{'host':'perf-results-elastic.apps.observability.perfscale.devcluster.openshift.com', 'port':443}],
+    http_compress = True, # enables gzip compression for request bodies
+    http_auth = ('<username>', '<password>'),
+    use_ssl = True,
+    verify_certs = False,
+    timeout=60
+    # max_retries=10, 
+    # retry_on_timeout=True
+)
+
+# To check if connected to server
+if not client.ping():
+    raise ValueError("Connection failed")
+
+
+with open(filename) as f:
+    for line in f:
+      data = json.loads(line)
+
+# Created index
+client.indices.create(index="ocm-api-data", ignore=400)
+
+# Below document is appended to the json file, as this foramt is used for bulk uploading the files to the ES server.
+action={
+    "index": {
+        "_index": "ocm-api-data"
+    }
+}
+
+# For Bulk Upload
+payload= payload_constructor(data, action)
+
+#To check if all the data is uploaded
+if not payload:
+  print("Successful")
+else:
+  response=client.bulk(body=payload_constructor(data,action),index="ocm-api-data")
+
+
+# Check all indexes present on the server
+for index in client.indices.get('*'):
+  print(index)

--- a/hack/ES_Upload.py
+++ b/hack/ES_Upload.py
@@ -1,6 +1,8 @@
 from opensearchpy import OpenSearch
 import json
 import sys
+filename= sys.argv[1]
+
 
 def payload_constructor(data,action):
     action_string = json.dumps(action) + "\n"
@@ -22,15 +24,11 @@ def payload_constructor(data,action):
 
 
 
-filename= sys.argv[1]
-
-
-
 # Create the client with SSL/TLS enabled, but hostname verification disabled.
 client = OpenSearch(
-    hosts = [{'host':'perf-results-elastic.apps.observability.perfscale.devcluster.openshift.com', 'port':443}],
+    hosts = [{'host':'search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com', 'port':443}],
     http_compress = True, # enables gzip compression for request bodies
-    http_auth = ('<username>', '<password>'),
+    #http_auth = ('<username>', '<password>'),
     use_ssl = True,
     verify_certs = False,
     timeout=60
@@ -65,8 +63,3 @@ if not payload:
   print("Successful")
 else:
   response=client.bulk(body=payload_constructor(data,action),index="ocm-api-data")
-
-
-# Check all indexes present on the server
-for index in client.indices.get('*'):
-  print(index)

--- a/hack/ES_Upload.py
+++ b/hack/ES_Upload.py
@@ -1,40 +1,39 @@
 from opensearchpy import OpenSearch
 import json
 import sys
-filename= sys.argv[1]
+filename = sys.argv[1]
 
 
-def payload_constructor(data,action):
+def payload_constructor(data, action):
     action_string = json.dumps(action) + "\n"
 
-    payload_string=""
-    count=0
+    payload_string = ""
+    count = 0
     for line in data:
         payload_string += action_string
         this_line = json.dumps(line) + "\n"
         payload_string += this_line
-        count+=1
+        count += 1
         if count == 100:
-          response=client.bulk(body=payload_string,index="ocm-api-data")
-          print(response)
-          count=0
-          payload_string=""
-        
-    return payload_string
+            response = client.bulk(body=payload_string, index="ocm-api-data")
+            count = 0
+            payload_string = ""
 
+    return payload_string
 
 
 # Create the client with SSL/TLS enabled, but hostname verification disabled.
 client = OpenSearch(
-    hosts = [{'host':'search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com', 'port':443}],
-    http_compress = True, # enables gzip compression for request bodies
-    #http_auth = ('<username>', '<password>'),
-    use_ssl = True,
-    verify_certs = False,
+    hosts=[{'host': 'search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com', 'port': 443}],
+    http_compress=True,  # enables gzip compression for request bodies
+    # http_auth = ('<username>', '<password>'),
+    use_ssl=True,
+    verify_certs=False,
     timeout=60
-    # max_retries=10, 
+    # max_retries=10,
     # retry_on_timeout=True
 )
+
 
 # To check if connected to server
 if not client.ping():
@@ -43,23 +42,23 @@ if not client.ping():
 
 with open(filename) as f:
     for line in f:
-      data = json.loads(line)
+        data = json.loads(line)
 
 # Created index
 client.indices.create(index="ocm-api-data", ignore=400)
 
-# Below document is appended to the json file, as this foramt is used for bulk uploading the files to the ES server.
-action={
+# Document appended to the json file,for bulk uploading to the ES server.
+action = {
     "index": {
         "_index": "ocm-api-data"
     }
 }
 
 # For Bulk Upload
-payload= payload_constructor(data, action)
+payload = payload_constructor(data, action)
 
-#To check if all the data is uploaded
+# To check if all the data is uploaded
 if not payload:
-  print("Successful")
+    print("Successful")
 else:
-  response=client.bulk(body=payload_constructor(data,action),index="ocm-api-data")
+    response = client.bulk(body=payload_constructor(data, action), index="ocm-api-data")

--- a/hack/ES_Upload.py
+++ b/hack/ES_Upload.py
@@ -24,7 +24,8 @@ def payload_constructor(data, action):
 
 # Create the client with SSL/TLS enabled, but hostname verification disabled.
 client = OpenSearch(
-    hosts=[{'host': 'search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com', 'port': 443}],
+    hosts=[{'host': 'search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com',
+            'port': 443}],
     http_compress=True,  # enables gzip compression for request bodies
     # http_auth = ('<username>', '<password>'),
     use_ssl=True,
@@ -61,4 +62,5 @@ payload = payload_constructor(data, action)
 if not payload:
     print("Successful")
 else:
-    response = client.bulk(body=payload_constructor(data, action), index="ocm-api-data")
+    response = client.bulk(body=payload_constructor(data, action),
+                           index="ocm-api-data")

--- a/hack/ES_Upload.py
+++ b/hack/ES_Upload.py
@@ -15,7 +15,7 @@ def payload_constructor(data, action):
         payload_string += this_line
         count += 1
         if count == 100:
-            response = client.bulk(body=payload_string, index="ocm-api-data")
+            client.bulk(body=payload_string, index="ocm-api-data")
             count = 0
             payload_string = ""
 

--- a/hack/restructure_file.py
+++ b/hack/restructure_file.py
@@ -1,0 +1,49 @@
+import json
+
+def hasbody(list1):
+    message=""
+    if list1["body"]:
+        message="True"
+    else:
+        message= "False"
+    return message
+
+def haserror(list2):
+    message1=""
+    if 200 <= (int(list2["code"])) <=299 :
+        message1="False"
+    else:
+        message1= "True"
+    return message1
+
+
+
+# Loading json file
+with open('/home/sahshah/Downloads/All_data/2022-04-20/requests/c750f388-3eb1-5baa-bfa3-13ec62b02ccd_self-terms-review.json') as f:
+    data = [json.loads(line) for line in f]
+
+
+# Adding the required fields
+version="version"
+version_value="b4d0329"
+has_error="has_error"
+has_body="has_body"
+uuid="uuid"
+uuid_value="c750f388-3eb1-5baa-bfa3-13ec62b02ccd"
+
+
+for i in data:
+    body_value = hasbody(i)
+    error_val = haserror(i)
+    i[version]=version_value
+    i[uuid]=uuid_value
+    i[has_body]=body_value
+    i[has_error]=error_val
+        
+
+# Dumping(saving) data into JSON file
+with open('/home/sahshah/Downloads/All_data/2022-04-20/requests/c750f388-3eb1-5baa-bfa3-13ec62b02ccd_self-terms-review.json',"w") as f:
+    json.dump(data, f)
+
+# Pretty print the loaded file
+print(json.dumps(data, indent=4,sort_keys=True))

--- a/hack/restructure_file.py
+++ b/hack/restructure_file.py
@@ -1,6 +1,12 @@
 import json
+import sys
 
-def hasbody(list1):
+filename= sys.argv[1]
+savefile= sys.argv[2]
+printfile= sys.argv[3]
+
+
+def has_body(list1):
     message=""
     if list1["body"]:
         message="True"
@@ -8,7 +14,7 @@ def hasbody(list1):
         message= "False"
     return message
 
-def haserror(list2):
+def has_error(list2):
     message1=""
     if 200 <= (int(list2["code"])) <=299 :
         message1="False"
@@ -19,31 +25,32 @@ def haserror(list2):
 
 
 # Loading json file
-with open('/home/sahshah/Downloads/All_data/2022-04-20/requests/c750f388-3eb1-5baa-bfa3-13ec62b02ccd_self-terms-review.json') as f:
+with open(filename) as f:
     data = [json.loads(line) for line in f]
 
 
 # Adding the required fields
 version="version"
 version_value="b4d0329"
-has_error="has_error"
-has_body="has_body"
+haserror="has_error"
+hasbody="has_body"
 uuid="uuid"
 uuid_value="c750f388-3eb1-5baa-bfa3-13ec62b02ccd"
 
 
 for i in data:
-    body_value = hasbody(i)
-    error_val = haserror(i)
+    body_value = has_body(i)
+    error_val = has_error(i)
     i[version]=version_value
     i[uuid]=uuid_value
-    i[has_body]=body_value
-    i[has_error]=error_val
+    i[hasbody]=body_value
+    i[haserror]=error_val
         
 
 # Dumping(saving) data into JSON file
-with open('/home/sahshah/Downloads/All_data/2022-04-20/requests/c750f388-3eb1-5baa-bfa3-13ec62b02ccd_self-terms-review.json',"w") as f:
+with open(savefile,"w") as f:
     json.dump(data, f)
 
 # Pretty print the loaded file
-print(json.dumps(data, indent=4,sort_keys=True))
+if printfile =='true':
+    print(json.dumps(data, indent=4,sort_keys=True))

--- a/hack/restructure_file.py
+++ b/hack/restructure_file.py
@@ -1,56 +1,54 @@
 import json
 import sys
 
-filename= sys.argv[1]
-savefile= sys.argv[2]
-printfile= sys.argv[3]
+filename = sys.argv[1]
+savefile = sys.argv[2]
+printfile = sys.argv[3]
 
 
-def has_body(list1):
-    message=""
-    if list1["body"]:
-        message="True"
+def has_body(item1):
+    hasbody = ""
+    if item1["body"]:
+        hasbody = "True"
     else:
-        message= "False"
-    return message
+        hasbody = "False"
+    return hasbody
 
-def has_error(list2):
-    message1=""
-    if 200 <= (int(list2["code"])) <=299 :
-        message1="False"
+
+def has_error(item2):
+    haserror = ""
+    if 200 <= (int(item2["code"])) <= 299:
+        haserror = "False"
     else:
-        message1= "True"
-    return message1
-
+        haserror = "True"
+    return haserror
 
 
 # Loading json file
 with open(filename) as f:
     data = [json.loads(line) for line in f]
 
-
 # Adding the required fields
-version="version"
-version_value="b4d0329"
-haserror="has_error"
-hasbody="has_body"
-uuid="uuid"
-uuid_value="c750f388-3eb1-5baa-bfa3-13ec62b02ccd"
-
+version = "version"
+version_value = "b4d0329"
+haserror = "has_error"
+hasbody = "has_body"
+uuid = "uuid"
+uuid_value = "c750f388-3eb1-5baa-bfa3-13ec62b02ccd"
 
 for i in data:
     body_value = has_body(i)
     error_val = has_error(i)
-    i[version]=version_value
-    i[uuid]=uuid_value
-    i[hasbody]=body_value
-    i[haserror]=error_val
-        
+    i[version] = version_value
+    i[uuid] = uuid_value
+    i[hasbody] = body_value
+    i[haserror] = error_val
+
 
 # Dumping(saving) data into JSON file
-with open(savefile,"w") as f:
+with open(savefile, "w") as f:
     json.dump(data, f)
 
 # Pretty print the loaded file
-if printfile =='true':
-    print(json.dumps(data, indent=4,sort_keys=True))
+if printfile == 'True':
+    print(json.dumps(data, indent=4, sort_keys=True))

--- a/hack/restructure_file.py
+++ b/hack/restructure_file.py
@@ -6,18 +6,18 @@ savefile = sys.argv[2]
 printfile = sys.argv[3]
 
 
-def has_body(item1):
+def has_body(item):
     hasbody = ""
-    if item1["body"]:
+    if item["body"]:
         hasbody = "True"
     else:
         hasbody = "False"
     return hasbody
 
 
-def has_error(item2):
+def has_error(item):
     haserror = ""
-    if 200 <= (int(item2["code"])) <= 299:
+    if 200 <= (int(item["code"])) <= 299:
         haserror = "False"
     else:
         haserror = "True"


### PR DESCRIPTION
### Description
I had to restructure the old ocm-api-data into new structure, as currently because of the different versions of the tool, not all OCM data has the same format and we are not able to compare older versions with new versions.
I have restructured the data and uploaded it on ES server. 
https://perf-results-kibana.apps.observability.perfscale.devcluster.openshift.com/app/discover#/?_g=(filters:!(),query:(language:kuery,query:''),refreshInterval:(pause:!t,value:0),time:(from:now-2y%2Fy,to:now))&_a=(columns:!(),filters:!(),index:'8cd68090-fe1c-11ec-a863-2724cf0131d6',interval:auto,query:(language:kuery,query:''),sort:!(!(timestamp,desc)))

### Fixes
Wrote two scripts :
1. restructure_file : To restructure the old ocm-api-data into the updated format.
2. ES_Upload: To upload the re-structured files to the elastic server