### PR TITLE
Added function for randomizing the Resource name and Count field

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
-	golang.org/x/exp v0.0.0-20191030013958-a1ab85dbe136 // indirect
+	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e // indirect
 	golang.org/x/net v0.0.0-20211216030914-fe4d6282115f // indirect
 	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
 	golang.org/x/text v0.3.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -140,6 +140,7 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
@@ -502,6 +503,8 @@ golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20191030013958-a1ab85dbe136 h1:A1gGSx58LAGVHUUsOf7IiR0u8Xb6W51gRwfDBhkdcaw=
 golang.org/x/exp v0.0.0-20191030013958-a1ab85dbe136/go.mod h1:JXzH8nQsPlswgeRAPE3MuO9GYsAcnJvJ4vnMwN/5qkY=
+golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e h1:+WEEuIdZHnUeJJmEUjyYC2gfUMj69yZXw17EnHg/otA=
+golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e/go.mod h1:Kr81I6Kryrl9sr8s2FK3vxD90NdsKWRuOIl2O4CvYbA=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/pkg/helpers/constants.go
+++ b/pkg/helpers/constants.go
@@ -5,9 +5,9 @@ const (
 	DefaultAWSRegion = "us-east-1"
 
 	// Cluster Auhtorization
-	M5XLargeResource           = "m5.xlarge"
 	AWSComputeNodeResourceType = "compute.node.aws"
-	DefaultClusterCount        = 4
+	MinClusterCount            = 4
+	MaxClusterCount            = 10
 	StandardBillingModel       = "standard"
 	OsdProductID               = "osd"
 	AWSCloudProvider           = "aws"
@@ -16,4 +16,8 @@ const (
 	ClusterAuthReserve         = true
 	ClusterAuthBYOC            = true
 	SingleAvailabilityZone     = "single"
+)
+
+var (
+	AWSResources = [5]string{"m3.2xlarge", "m4.large", "m4.xlarge", "m5.large", "m5.xlarge"}
 )

--- a/pkg/tests/handlers/accounts.go
+++ b/pkg/tests/handlers/accounts.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"math/rand"
 	"net/http"
 	"strings"
 	"time"
@@ -226,12 +227,26 @@ func TestClusterAuthorizations(ctx context.Context, options *types.TestOptions) 
 	return nil
 }
 
+func randomizeResourceName() string {
+	resourcenamelist := helpers.AWSResources
+	resourceName := resourcenamelist[rand.Intn(len(resourcenamelist))]
+	return resourceName
+}
+
+func randomizeCount() int {
+	min_count := helpers.MinClusterCount
+	max_count := helpers.MaxClusterCount
+	count := min_count + rand.Intn(max_count-min_count)
+	return count
+}
+
 func clusterAuthorizationsBody(ctx context.Context, clusterID string, options *types.TestOptions) []byte {
+	rand.Seed(time.Now().UnixNano())
 	buff := &bytes.Buffer{}
 	reservedResource := v1.NewReservedResource().
-		ResourceName(helpers.M5XLargeResource).
+		ResourceName(randomizeResourceName()).
 		ResourceType(helpers.AWSComputeNodeResourceType).
-		Count(helpers.DefaultClusterCount).
+		Count(randomizeCount()).
 		BillingModel(helpers.StandardBillingModel)
 
 	clusterAuthReq, err := v1.NewClusterAuthorizationRequest().

--- a/pkg/tests/handlers/accounts_test.go
+++ b/pkg/tests/handlers/accounts_test.go
@@ -1,0 +1,100 @@
+package handlers
+
+import (
+	"context"
+	"math/rand"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cloud-bulldozer/ocm-api-load/pkg/logging"
+	"github.com/cloud-bulldozer/ocm-api-load/pkg/types"
+)
+
+func Test_clusterAuthorizationsBody(t *testing.T) {
+	type args struct {
+		ctx       context.Context
+		clusterID string
+		options   *types.TestOptions
+	}
+	logger, _ := logging.NewGoLoggerBuilder().Build()
+	tests := []struct {
+		name string
+		args args
+	}{
+
+		{"randomize-1", args{context.TODO(), "clusterID-1", &types.TestOptions{Logger: logger}}},
+		{"randomize-2", args{context.TODO(), "clusterID-2", &types.TestOptions{Logger: logger}}},
+		{"randomize-3", args{context.TODO(), "clusterID-3", &types.TestOptions{Logger: logger}}},
+		{"randomize-4", args{context.TODO(), "clusterID-4", &types.TestOptions{Logger: logger}}},
+		{"randomize-5", args{context.TODO(), "clusterID-5", &types.TestOptions{Logger: logger}}},
+		{"randomize-6", args{context.TODO(), "clusterID-6", &types.TestOptions{Logger: logger}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := clusterAuthorizationsBody(tt.args.ctx, tt.args.clusterID, tt.args.options)
+			if got == nil {
+				t.Errorf("clusterAuthorizationsBody() = %v", got)
+			} else {
+				if !strings.Contains(string(got), tt.args.clusterID) {
+					t.Errorf("Clusterid not in body = %v, Expected = %v", string(got), tt.args.clusterID)
+				}
+			}
+		})
+	}
+}
+
+func Test_randomizeCount(t *testing.T) {
+	rand.Seed(time.Now().UnixNano())
+	tests := []struct {
+		name     string
+		mincount int
+		maxcount int
+	}{
+		{"Testing range of random count generated-1", 4, 10},
+		{"Testing range of random count generated-2", 4, 10},
+		{"Testing range of random count generated-3", 4, 10},
+		{"Testing range of random count generated-4", 4, 10},
+		{"Testing range of random count generated-5", 4, 10},
+		{"Testing range of random count generated-6", 4, 10},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := randomizeCount()
+			if !(got >= tt.mincount && got <= tt.maxcount) {
+				t.Errorf("randomizeCount() = %v, Expected count to be within range %v and %v", got, tt.mincount, tt.maxcount)
+			}
+		})
+	}
+}
+
+func Test_randomizeResourceName(t *testing.T) {
+	rand.Seed(time.Now().UnixNano())
+	resourcenames := [5]string{"m3.2xlarge", "m4.large", "m4.xlarge", "m5.large", "m5.xlarge"}
+	tests := []struct {
+		name          string
+		resourcenames [5]string
+	}{
+		{"Testing to check if output returned is from AWSResourcename-1", resourcenames},
+		{"Testing to check if output returned is from AWSResourcename-2", resourcenames},
+		{"Testing to check if output returned is from AWSResourcename-3", resourcenames},
+		{"Testing to check if output returned is from AWSResourcename-4", resourcenames},
+		{"Testing to check if output returned is from AWSResourcename-5", resourcenames},
+		{"Testing to check if output returned is from AWSResourcename-6", resourcenames},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := randomizeResourceName()
+			result := false
+			for _, resourcename := range tt.resourcenames {
+				if resourcename == got {
+					result = true
+					break
+				}
+			}
+			if !result {
+				t.Errorf("randomizeResourceName() = %v, Expected from list %v ", got, resourcenames)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description
The function that is  building the body for one end-point we test, has  all the variable options hard-coded. We want them to be variable and that we are able to call the end-point with different options so we don't hit a cache mechanism that the OCM-API team has implemented.
### Fixes
Added function for randomizing the Resource name and Count field