### PR TITLE
Updated the image resources file to Centos9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 FROM fedora:37
 
-COPY image_resources/centos8.repo image_resources/centos8-appstream.repo /etc/yum.repos.d/
-RUN dnf install -y --nodocs python3 python3-pip python3-devel gcc && dnf clean all && \
-    dnf install -y --nodocs skopeo curl redis --enablerepo=centos8-appstream && dnf clean all && \
+COPY image_resources/centos9.repo image_resources/centos9-appstream.repo /etc/yum.repos.d/
+RUN dnf install -y --nodocs python3 python3-pip python3-devel-3.9.13-2.el9.x86_64 gcc && dnf clean all && \
+    dnf install -y --nodocs curl skopeo redis --enablerepo=centos9-appstream && dnf clean all && \
     ln -s /usr/bin/python3 /usr/bin/python
+
 WORKDIR /workdir
 
 RUN curl -L -o ocm-load-test-linux.tgz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM fedora:37
 
 COPY image_resources/centos9.repo image_resources/centos9-appstream.repo /etc/yum.repos.d/
 RUN dnf install -y --nodocs python3 python3-pip python3-devel-3.9.13-2.el9.x86_64 gcc && dnf clean all && \
-    dnf install -y --nodocs curl skopeo redis --enablerepo=centos9-appstream && dnf clean all && \
+    dnf install -y --nodocs rsync tar curl skopeo redis --enablerepo=centos9-appstream && dnf clean all && \
     ln -s /usr/bin/python3 /usr/bin/python
 
 WORKDIR /workdir

--- a/image_resources/centos8-appstream.repo
+++ b/image_resources/centos8-appstream.repo
@@ -1,5 +1,0 @@
-[centos8-appstream]
-name=CentOS-8-Appstream
-baseurl=http://mirror.centos.org/centos/8-stream/AppStream/$basearch/os/
-enabled=0
-gpgcheck=0

--- a/image_resources/centos8.repo
+++ b/image_resources/centos8.repo
@@ -1,5 +1,0 @@
-[centos8]
-name=CentOS-8
-baseurl=http://mirror.centos.org/centos/8-stream/BaseOS/$basearch/os/
-enabled=0
-gpgcheck=0

--- a/image_resources/centos9-appstream.repo
+++ b/image_resources/centos9-appstream.repo
@@ -1,0 +1,5 @@
+[centos9-appstream]
+name=CentOS-9-Appstream
+baseurl=http://mirror.stream.centos.org/9-stream/AppStream/$basearch/os/
+enabled=1
+gpgcheck=0

--- a/image_resources/centos9.repo
+++ b/image_resources/centos9.repo
@@ -1,0 +1,5 @@
+[centos9]
+name=CentOS-9
+baseurl=http://mirror.stream.centos.org/9-stream/BaseOS/$basearch/os/
+enabled=1
+gpgcheck=0


### PR DESCRIPTION
### Description
I was trying to solve Issue #51 and found that we needed some updates to build the image.
### Fixes
Updated from Centos8 to Centos9 and specified a specific package of python3-devel.