### PR TITLE
remove patch service for ci

### DIFF
--- a/ci/templates/config.yaml
+++ b/ci/templates/config.yaml
@@ -59,6 +59,3 @@ tests:
   get-services:
     rate: "$GET_SERVICES_RATE"
     duration: $GET_SERVICES_DURATION
-  patch-services:
-    rate: "$PATCH_SERVICES_RATE"
-    duration: $PATCH_SERVICES_DURATION


### PR DESCRIPTION
patch_service endpoint is failing[1] so removing it from CI till it gets fixed.

[1] https://github.com/cloud-bulldozer/ocm-api-load/issues/91

### Description

### Fixes
