### PR TITLE
fix patch services

### DIFF
--- a/ci/templates/config.yaml
+++ b/ci/templates/config.yaml
@@ -15,7 +15,7 @@ elastic:
     insecure-skip-verify: true
 duration: $DURATION
 cooldown: $COOLDOWN
-output-path: "/tmp/$UUID/results"
+output-path: "./results"
 rate: "$RATE"
 test-id: $UUID
 ramp-type: $RAMP_TYPE


### PR DESCRIPTION
1. correctly pass fake_cluster option
2. Second cluster creation is faling as idx is alwasy 0, so instead use iterator index
3. append 'a' to aws region to create cluster in us-west-2a
4. Patching is allowed only when the service is in "waiting for addon" state. So wait till the service reachs this state before issuing PATCH request
5. Only "Parameters" option is allowed with patching, so remove passing Service and Cluster options
