### PR TITLE
fix broken cli option

### DIFF
--- a/cmd/ocm-load-test.go
+++ b/cmd/ocm-load-test.go
@@ -176,8 +176,8 @@ func run(cmd *cobra.Command, args []string) error {
                 os.Exit(1)
         }
 
-	if viper.Sub("ocm") == nil {
-		logger.Fatal(cmd.Context(), "ocm is a necessary configuration")
+	if viper.Sub("ocm") == nil && viper.GetString("ocm-token") == "" {
+		logger.Fatal(cmd.Context(), "ocm section or ocm-token is necessary configuration")
 	}
 	err = helpers.CreateFolder(cmd.Context(), viper.GetString("output-path"), logger)
 	if err != nil {

--- a/pkg/ocm/connection.go
+++ b/pkg/ocm/connection.go
@@ -47,7 +47,18 @@ func BuildConnection(gateway, clientID, clientSecret, token string, logger loggi
 
 func BuildConnections(ctx context.Context, logger logging.Logger) ([]*sdk.Connection, error) {
 	connections := make([]*sdk.Connection, 0)
-	auths := viper.GetStringMap("ocm")["auths"].([]interface{})
+
+	var auths []interface{}
+	if viper.Sub("ocm") != nil {
+		auths = viper.GetStringMap("ocm")["auths"].([]interface{})
+	} else if viper.GetString("ocm-token") != "" {
+		auth := map[string]interface{}{
+				"token": viper.GetString("ocm-token"),
+				"client-id": viper.GetString("client.id"),
+				"client-secret": viper.GetString("client.secret"),
+			}
+		auths = append(auths, auth)
+	}
 	for _, a := range auths {
 		m := a.(map[string]interface{})
 		token, ok := m["token"]


### PR DESCRIPTION
ocm-api-load is working only with config file and failing with cli arguments as it is accepting ocm account details from only config file. This change accepts ocm account details from cli if the config file is not provided.

