### PR TITLE
start cluster name with pocm

### DIFF
--- a/pkg/tests/handlers/clusters.go
+++ b/pkg/tests/handlers/clusters.go
@@ -56,7 +56,7 @@ func generateCreateClusterTargeter(ctx context.Context, ID, method, url string, 
 			"fake_cluster": "true",
 		}
 		body, err := v1.NewCluster().
-			Name(fmt.Sprintf("perf-%s-%d", id, idx)).
+			Name(fmt.Sprintf("pocm-%s-%d", id, idx)).
 			Properties(fakeClusterProps).
 			MultiAZ(true).
 			Region(v1.NewCloudRegion().ID(ccsRegion)).

--- a/pkg/tests/handlers/services.go
+++ b/pkg/tests/handlers/services.go
@@ -65,7 +65,7 @@ func generateCreateServiceTargeter(ctx context.Context, ID, method, url string, 
 			Service("ocm-addon-test-operator").
 			Parameters(v1.NewServiceParameter().ID("has-external-resources").Value("false")).
 			Cluster(v1.NewCluster().
-				Name(fmt.Sprintf("perf-%s-%d", id, idx)).
+				Name(fmt.Sprintf("pocm-%s-%d", id, idx)).
 				AWS(
 					v1.NewAWS().
 						AccessKeyID(ccsAccessKey).
@@ -132,7 +132,7 @@ func TestPatchService(ctx context.Context, options *types.TestOptions) error {
 			Service("ocm-addon-test-operator").
 			Parameters(v1.NewServiceParameter().ID("has-external-resources").Value("false")).
 			Cluster(v1.NewCluster().
-				Name(fmt.Sprintf("perf-%s-%d", id, i)).
+				Name(fmt.Sprintf("pocm-%s-%d", id, i)).
 				AWS(
 					v1.NewAWS().
 						AccessKeyID(ccsAccessKey).


### PR DESCRIPTION
Use pocm-<uudi> in cluster and service names instead of perf-<uuid>. This allows us to identify and remove any stale resources generated by ocm-api-load.
