### PR TITLE
Add aws tags to cluster

### DIFF
--- a/pkg/tests/handlers/clusters.go
+++ b/pkg/tests/handlers/clusters.go
@@ -56,7 +56,7 @@ func generateCreateClusterTargeter(ctx context.Context, ID, method, url string, 
 			"fake_cluster": "true",
 		}
 		body, err := v1.NewCluster().
-			Name(fmt.Sprintf("perf-%s-%d", id, idx)).
+			Name(fmt.Sprintf("pocm-%s-%d", id, idx)).
 			Properties(fakeClusterProps).
 			MultiAZ(true).
 			Region(v1.NewCloudRegion().ID(ccsRegion)).

--- a/pkg/tests/handlers/clusters.go
+++ b/pkg/tests/handlers/clusters.go
@@ -55,6 +55,9 @@ func generateCreateClusterTargeter(ctx context.Context, ID, method, url string, 
 		fakeClusterProps := map[string]string{
 			"fake_cluster": "true",
 		}
+		awsTags := map[string]string{
+			"User": "pocm-perf",
+		}
 		body, err := v1.NewCluster().
 			Name(fmt.Sprintf("pocm-%s-%d", id, idx)).
 			Properties(fakeClusterProps).
@@ -65,7 +68,8 @@ func generateCreateClusterTargeter(ctx context.Context, ID, method, url string, 
 				v1.NewAWS().
 					AccessKeyID(ccsAccessKey).
 					SecretAccessKey(ccsSecretKey).
-					AccountID(ccsAccountID),
+					AccountID(ccsAccountID).
+					Tags(awsTags),
 			).
 			Build()
 		if err != nil {

--- a/pkg/tests/handlers/services.go
+++ b/pkg/tests/handlers/services.go
@@ -65,7 +65,7 @@ func generateCreateServiceTargeter(ctx context.Context, ID, method, url string, 
 			Service("ocm-addon-test-operator").
 			Parameters(v1.NewServiceParameter().ID("has-external-resources").Value("false")).
 			Cluster(v1.NewCluster().
-				Name(fmt.Sprintf("perf-%s-%d", id, idx)).
+				Name(fmt.Sprintf("pocm-%s-%d", id, idx)).
 				AWS(
 					v1.NewAWS().
 						AccessKeyID(ccsAccessKey).
@@ -132,7 +132,7 @@ func TestPatchService(ctx context.Context, options *types.TestOptions) error {
 			Service("ocm-addon-test-operator").
 			Parameters(v1.NewServiceParameter().ID("has-external-resources").Value("false")).
 			Cluster(v1.NewCluster().
-				Name(fmt.Sprintf("perf-%s-%d", id, i)).
+				Name(fmt.Sprintf("pocm-%s-%d", id, i)).
 				AWS(
 					v1.NewAWS().
 						AccessKeyID(ccsAccessKey).

--- a/pkg/tests/handlers/services.go
+++ b/pkg/tests/handlers/services.go
@@ -60,6 +60,9 @@ func generateCreateServiceTargeter(ctx context.Context, ID, method, url string, 
 			"rosa_creator_arn": arn,
 			"fake_cluster": "true",
 		}
+		awsTags := map[string]string{
+			"User": "pocm-perf",
+		}
 
 		body, err := v1.NewManagedService().
 			Service("ocm-addon-test-operator").
@@ -70,7 +73,8 @@ func generateCreateServiceTargeter(ctx context.Context, ID, method, url string, 
 					v1.NewAWS().
 						AccessKeyID(ccsAccessKey).
 						SecretAccessKey(ccsSecretKey).
-						AccountID(ccsAccountID),
+						AccountID(ccsAccountID).
+					        Tags(awsTags),
 				).
 				Nodes(v1.NewClusterNodes().AvailabilityZones(fmt.Sprintf("%sa", ccsRegion))).
 				Properties(creatorProps).
@@ -123,6 +127,9 @@ func TestPatchService(ctx context.Context, options *types.TestOptions) error {
 		"rosa_creator_arn": arn,
 		"fake_cluster": "true",
 	}
+	awsTags := map[string]string{
+		"User": "pocm-perf",
+	}
 
 	// Register multiple mock Services and store their IDs
 	options.Logger.Info(ctx, "Registering 2 Services to use for patch requests test")
@@ -137,7 +144,8 @@ func TestPatchService(ctx context.Context, options *types.TestOptions) error {
 					v1.NewAWS().
 						AccessKeyID(ccsAccessKey).
 						SecretAccessKey(ccsSecretKey).
-						AccountID(ccsAccountID),
+						AccountID(ccsAccountID).
+					        Tags(awsTags),
 				).
 				Nodes(v1.NewClusterNodes().AvailabilityZones(fmt.Sprintf("%sa", ccsRegion))).
 				Properties(creatorProps).


### PR DESCRIPTION
Add aws tags to clusters created by create-cluster, create-services
and patch-services tests.