### PR TITLE
Fixes #51

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM  registry.access.redhat.com/ubi9:latest
 
-RUN dnf install -y --nodocs skopeo
+RUN dnf install -y --nodocs skopeo && \
+    dnf clean all
 COPY image_resources/centos9.repo image_resources/centos9-appstream.repo /etc/yum.repos.d/
 RUN dnf install -y --nodocs python3-pip python3-devel gcc && \
     dnf install -y --nodocs --nobest rsync redis && \


### PR DESCRIPTION
This PR does the following:

1) Switch to UBI9, preloaded with python39, tar, curl 
2) Install skopeo first, then rest

Signed-off-by: Krishna Harsha Voora <krvoora@redhat.com>

### Fixes
#51