### PR TITLE
set expiration_timestamp for cluster

### DIFF
--- a/pkg/helpers/clean_test_transport.go
+++ b/pkg/helpers/clean_test_transport.go
@@ -204,7 +204,7 @@ func addTestProperties(body string) (string, error) {
 	}
 	properties["user"] = user.Name
 	cluster["properties"] = properties
-	if cluster["expiration_timestamp"] == "" {
+	if cluster["expiration_timestamp"] == nil {
 		cluster["expiration_timestamp"] = time.Now().Add(time.Hour).Format(time.RFC3339)
 	}
 	result, err := json.Marshal(cluster)


### PR DESCRIPTION
It sets expiration_timestamp for the clusters created by clusters_mgmt endpoints. We need to work on fixing [1] i.e setting expiration_timestamp for clusters created by services (i.e service_mgmt endpoint). We will disable testing service_mgmt endpoints in CI till this gets fixed.

[1] https://github.com/cloud-bulldozer/ocm-api-load/issues/102
