### PR TITLE
Fixes missing metrics, adds bucketed count

### DIFF
--- a/pkg/tests/run.go
+++ b/pkg/tests/run.go
@@ -74,7 +74,13 @@ func (r *Runner) Run(ctx context.Context) error {
 
 				var metrics vegeta.Metrics
 				metrics.Histogram = &vegeta.Histogram{
-					Buckets: vegeta.Buckets{time.Millisecond},
+					Buckets: vegeta.Buckets{0 * time.Millisecond,
+						50 * time.Millisecond,
+						100 * time.Millisecond,
+						300 * time.Millisecond,
+						500 * time.Millisecond,
+						1000 * time.Millisecond,
+						5000 * time.Millisecond},
 				}
 
 				// Bind "Test Harness"
@@ -141,17 +147,15 @@ func (r *Runner) Run(ctx context.Context) error {
 						}
 					}
 				}
+				testOptions.Metrics.Close()
 
 				// Index result file
-
 				serverVersion := helpers.GetServerVersion(ctx, conn)
 				r.logger.Info(ctx, "server version %s", serverVersion)
 				err = elastic.IndexFile(ctx, r.testID, serverVersion, testOptions.TestName, fileName, *testOptions.Metrics, r.logger)
 				if err != nil {
 					r.logger.Error(ctx, "%s", err)
 				}
-
-				testOptions.Metrics.Close()
 				wg.Done()
 				return nil
 			}(ctx, concurrentConnections, i, conn, t)


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Fixes missing metrics like mean, and percentailes, this happened because I was not closing the metrics object before indexing the data.

Since I am doing changes, I also added more buckets to have a more sparse count of events.

<!--- Describe your changes in detail -->

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
